### PR TITLE
Avoid memset when clearing an empty table

### DIFF
--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1490,8 +1490,10 @@ public:
     // modifiers //////////////////////////////////////////////////////////////
 
     void clear() {
-        m_values.clear();
-        clear_buckets();
+        if (!empty()) {
+            m_values.clear();
+            clear_buckets();
+        }
     }
 
     auto insert(value_type const& value) -> std::pair<iterator, bool> {


### PR DESCRIPTION
`clear_buckets` memsets all buckets to 0. If the table is already empty, there is no need to do so, and we can save a little bit of time. Helpful when clearing a bigger data structure that contains multiple maps, some of which may be empty.