### PR TITLE
Speed up hashing, probing, and erase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ Benchmarking practices:
 
 - Always benchmark a `--buildtype release` build (never debug).
 - Record a baseline score on the unmodified code first, then compare after each change. Run each measurement 2–3 times; treat differences within run-to-run noise (~1–2%) as no change.
+- On noisy/shared machines, don't compare runs made at different times — the machine can drift by >10% over minutes. Instead keep a baseline binary around (copy `udm-test` elsewhere before rebuilding) and run baseline and candidate **interleaved** (A B A B A B), then compare paired runs. A change is real when it wins in (almost) every pair.
+- Beware code-layout luck: any edit (even to never-executed code) can shift alignment and move individual sub-benchmarks by ±3%. Judge micro-optimizations by mechanism plus a focused microbenchmark, and confirm on the paired geomean, not on a single sub-benchmark delta.
 - nanobench prints per-benchmark `err%`; rerun if it's high (> ~3%). A warning about CPU governor/turbo is normal on non-tuned machines — it just means more noise.
 - Other useful benchmarks in `test/bench/` (e.g. `bench_copy`, `bench_game_of_life`, find variants) can be run the same way via `-tc=<name>`; run all with `-ns -ts=bench`. List all test cases with `-ltc`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# CLAUDE.md
+
+Guidance for working on `unordered_dense` — a single-header C++17 dense open-addressing hash map/set (`ankerl::unordered_dense::{map, set}`).
+
+The entire implementation lives in `include/ankerl/unordered_dense.h`. Tests and benchmarks are in `test/` and build into a single doctest executable `udm-test`.
+
+## Build (meson)
+
+Meson and ninja are required (`pip install -r requirements.txt` if missing). Dependencies (doctest, fmt) are fetched automatically as meson subprojects via `subprojects/*.wrap`.
+
+```sh
+# one-time setup of a release build (required for benchmarking; also sets -DNDEBUG)
+CXX="ccache clang++" meson setup --buildtype release builddir/clang_release
+
+# compile (incremental, run after every change)
+ninja -C builddir/clang_release
+```
+
+A debug build for development: `CXX="ccache clang++" meson setup builddir/clang_debug`.
+
+Warnings are errors (`werror=true`, `warning_level=3`, plus `-Wconversion`, `-Wold-style-cast`, …), so code must compile clean.
+
+## Benchmarking
+
+The main performance metric is `bench_quick_overall_udm`. It runs six nanobench benchmarks covering the most important primitives — iterate-while-modifying, random insert/erase, and random find (50% hit rate) — each for both `map<uint64_t, size_t>` and `map<std::string, size_t>`, then prints the geometric mean of the median elapsed times:
+
+```sh
+# benchmarks are marked doctest::skip(), so -ns (no-skip) is required
+./builddir/clang_release/test/udm-test -ns -tc=bench_quick_overall_udm
+```
+
+The last line of output is the score, e.g.:
+
+```
+0.0767 bench_quick_overall_map_udm
+```
+
+**Lower is better.** This single number is what to optimize.
+
+Benchmarking practices:
+
+- Always benchmark a `--buildtype release` build (never debug).
+- Record a baseline score on the unmodified code first, then compare after each change. Run each measurement 2–3 times; treat differences within run-to-run noise (~1–2%) as no change.
+- nanobench prints per-benchmark `err%`; rerun if it's high (> ~3%). A warning about CPU governor/turbo is normal on non-tuned machines — it just means more noise.
+- Other useful benchmarks in `test/bench/` (e.g. `bench_copy`, `bench_game_of_life`, find variants) can be run the same way via `-tc=<name>`; run all with `-ns -ts=bench`. List all test cases with `-ltc`.
+
+## Testing
+
+Any change to `include/ankerl/unordered_dense.h` must pass the unit tests:
+
+```sh
+meson test -C builddir/clang_release unit --verbose
+# or directly (runs all non-skipped tests):
+./builddir/clang_release/test/udm-test
+```
+
+## Notes for sandboxed / offline environments
+
+If meson cannot download the wrap subprojects (e.g. GitHub release tarballs blocked), fetch the doctest and fmt sources manually into `subprojects/doctest-2.4.12/` and `subprojects/fmt-11.2.0/` (matching the `directory` field of the `.wrap` files) with a minimal `meson.build` in each that declares `doctest_dep` (header-only, include dir `doctest/`) and `fmt_dep` (include dir `include/`, sources `src/format.cc`, `src/os.cc`) and calls `meson.override_dependency()`. Meson skips the download when the subproject directory already exists. These directories are gitignored — do not commit them.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 cmake_minimum_required(VERSION ${CMAKEVER})
 project("unordered_dense"
-    VERSION 4.8.1
+    VERSION 4.9.0
     DESCRIPTION "A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion"
     HOMEPAGE_URL "https://github.com/martinus/unordered_dense"
     LANGUAGES CXX)

--- a/include/ankerl/stl.h
+++ b/include/ankerl/stl.h
@@ -1,7 +1,7 @@
 ///////////////////////// ankerl::unordered_dense::{map, set} /////////////////////////
 
 // A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion.
-// Version 4.8.1
+// Version 4.9.0
 // https://github.com/martinus/unordered_dense
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -276,6 +276,16 @@ inline void mum(std::uint64_t* a, std::uint64_t* b) {
                     i -= 48;
                 }
                 seed ^= see1 ^ see2;
+                while (i > 16) {
+                    seed = mix(r8(p) ^ secret[1], r8(p + 8) ^ seed);
+                    i -= 16;
+                    p += 16;
+                }
+
+                // the tail lane only depends on the input, not on seed, so it can execute in parallel
+                // with the lane loops above, and a single dependent mix finishes the hash
+                auto tail = mix(r8(p + i - 16) ^ secret[2], r8(p + i - 8) ^ secret[3]);
+                return mix(secret[1] ^ len, seed ^ tail);
             }
         while (ANKERL_UNORDERED_DENSE_UNLIKELY(i > 16))
             ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1,7 +1,7 @@
 ///////////////////////// ankerl::unordered_dense::{map, set} /////////////////////////
 
 // A fast & densely stored hashmap and hashset based on robin-hood backward shift deletion.
-// Version 4.8.1
+// Version 4.9.0
 // https://github.com/martinus/unordered_dense
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
@@ -31,8 +31,8 @@
 
 // see https://semver.org/spec/v2.0.0.html
 #define ANKERL_UNORDERED_DENSE_VERSION_MAJOR 4 // NOLINT(cppcoreguidelines-macro-usage) incompatible API changes
-#define ANKERL_UNORDERED_DENSE_VERSION_MINOR 8 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible functionality
-#define ANKERL_UNORDERED_DENSE_VERSION_PATCH 1 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible bug fixes
+#define ANKERL_UNORDERED_DENSE_VERSION_MINOR 9 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible functionality
+#define ANKERL_UNORDERED_DENSE_VERSION_PATCH 0 // NOLINT(cppcoreguidelines-macro-usage) backwards compatible bug fixes
 
 // API versioning with inline namespace, see https://www.foonathan.net/2018/11/inline-namespaces/
 

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -70,6 +70,13 @@
 #    define ANKERL_UNORDERED_DENSE_NOINLINE __attribute__((noinline))
 #endif
 
+// data prefetch hint, a no-op when not supported
+#if defined(__GNUC__) || defined(__clang__)
+#    define ANKERL_UNORDERED_DENSE_PREFETCH(addr) __builtin_prefetch(addr) // NOLINT(cppcoreguidelines-macro-usage)
+#else
+#    define ANKERL_UNORDERED_DENSE_PREFETCH(addr) static_cast<void>(addr) // NOLINT(cppcoreguidelines-macro-usage)
+#endif
+
 #if defined(__clang__) && defined(__has_attribute)
 #    if __has_attribute(__no_sanitize__)
 #        define ANKERL_UNORDERED_DENSE_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK \
@@ -212,7 +219,10 @@ inline void mum(std::uint64_t* a, std::uint64_t* b) {
     static constexpr auto secret = std::array{UINT64_C(0xa0761d6478bd642f),
                                               UINT64_C(0xe7037ed1a0b428db),
                                               UINT64_C(0x8ebc6af09c88c6e3),
-                                              UINT64_C(0x589965cc75374cc3)};
+                                              UINT64_C(0x589965cc75374cc3),
+                                              UINT64_C(0x2d358dccaa6c78a5),
+                                              UINT64_C(0x8bb84b93962eacc9),
+                                              UINT64_C(0x4b33a62ed433d4a3)};
 
     auto const* p = static_cast<std::uint8_t const*>(key);
     std::uint64_t seed = secret[0];
@@ -241,13 +251,30 @@ inline void mum(std::uint64_t* a, std::uint64_t* b) {
             ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
                 std::uint64_t see1 = seed;
                 std::uint64_t see2 = seed;
-                do {
+                if (i > 96) {
+                    // 6 independent lanes: twice the instruction level parallelism of the 48 byte loop below
+                    std::uint64_t see3 = seed;
+                    std::uint64_t see4 = seed;
+                    std::uint64_t see5 = seed;
+                    do {
+                        seed = mix(r8(p) ^ secret[1], r8(p + 8) ^ seed);
+                        see1 = mix(r8(p + 16) ^ secret[2], r8(p + 24) ^ see1);
+                        see2 = mix(r8(p + 32) ^ secret[3], r8(p + 40) ^ see2);
+                        see3 = mix(r8(p + 48) ^ secret[4], r8(p + 56) ^ see3);
+                        see4 = mix(r8(p + 64) ^ secret[5], r8(p + 72) ^ see4);
+                        see5 = mix(r8(p + 80) ^ secret[6], r8(p + 88) ^ see5);
+                        p += 96;
+                        i -= 96;
+                    } while (ANKERL_UNORDERED_DENSE_LIKELY(i > 96));
+                    seed ^= see3 ^ see4 ^ see5;
+                }
+                while (i > 48) {
                     seed = mix(r8(p) ^ secret[1], r8(p + 8) ^ seed);
                     see1 = mix(r8(p + 16) ^ secret[2], r8(p + 24) ^ see1);
                     see2 = mix(r8(p + 32) ^ secret[3], r8(p + 40) ^ see2);
                     p += 48;
                     i -= 48;
-                } while (ANKERL_UNORDERED_DENSE_LIKELY(i > 48));
+                }
                 seed ^= see1 ^ see2;
             }
         while (ANKERL_UNORDERED_DENSE_UNLIKELY(i > 16))
@@ -943,18 +970,14 @@ private:
     value_container_type m_values{}; // Contains all the key-value pairs in one densely stored container. No holes.
     bucket_container_type m_buckets{};
     std::size_t m_max_bucket_capacity = 0;
+    value_idx_type m_bucket_mask = 0; // bucket_count() - 1; works because bucket_count() is always a power of two
     float m_max_load_factor = default_max_load_factor;
     Hash m_hash{};
     KeyEqual m_equal{};
     std::uint8_t m_shifts = initial_shifts;
 
     [[nodiscard]] auto next(value_idx_type bucket_idx) const -> value_idx_type {
-        if (ANKERL_UNORDERED_DENSE_UNLIKELY(bucket_idx + 1U == bucket_count()))
-            ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
-                return 0;
-            }
-
-        return static_cast<value_idx_type>(bucket_idx + 1U);
+        return static_cast<value_idx_type>((bucket_idx + 1U) & m_bucket_mask);
     }
 
     // Helper to access bucket through pointer types
@@ -1023,21 +1046,26 @@ private:
     }
 
     void place_and_shift_up(Bucket bucket, value_idx_type place) {
+        // cache mask in a local so the bucket stores can't alias it
+        auto const mask = m_bucket_mask;
         while (0 != at(m_buckets, place).m_dist_and_fingerprint) {
             bucket = std::exchange(at(m_buckets, place), bucket);
             bucket.m_dist_and_fingerprint = dist_inc(bucket.m_dist_and_fingerprint);
-            place = next(place);
+            place = static_cast<value_idx_type>((place + 1U) & mask);
         }
         at(m_buckets, place) = bucket;
     }
 
     void erase_and_shift_down(value_idx_type bucket_idx) {
+        // cache mask in a local so the bucket stores can't alias it
+        auto const mask = m_bucket_mask;
+
         // shift down until either empty or an element with correct spot is found
-        auto next_bucket_idx = next(bucket_idx);
+        auto next_bucket_idx = static_cast<value_idx_type>((bucket_idx + 1U) & mask);
         while (at(m_buckets, next_bucket_idx).m_dist_and_fingerprint >= Bucket::dist_inc * 2) {
             auto& next_bucket = at(m_buckets, next_bucket_idx);
             at(m_buckets, bucket_idx) = {dist_dec(next_bucket.m_dist_and_fingerprint), next_bucket.m_value_idx};
-            bucket_idx = std::exchange(next_bucket_idx, next(next_bucket_idx));
+            bucket_idx = std::exchange(next_bucket_idx, static_cast<value_idx_type>((next_bucket_idx + 1U) & mask));
         }
         at(m_buckets, bucket_idx) = {};
     }
@@ -1085,10 +1113,12 @@ private:
         m_buckets.clear();
         m_buckets.shrink_to_fit();
         m_max_bucket_capacity = 0;
+        m_bucket_mask = 0;
     }
 
     void allocate_buckets_from_shift() {
         auto num_buckets = calc_num_buckets(m_shifts);
+        m_bucket_mask = static_cast<value_idx_type>(num_buckets - 1);
         if constexpr (IsSegmented || !std::is_same_v<BucketContainer, default_container_t>) {
             if constexpr (has_reserve<bucket_container_type>) {
                 m_buckets.reserve(num_buckets);
@@ -1146,6 +1176,11 @@ private:
     template <typename Op>
     void do_erase(value_idx_type bucket_idx, Op handle_erased_value) {
         auto const value_idx_to_remove = at(m_buckets, bucket_idx).m_value_idx;
+
+        // both values are needed after the shift down; start fetching them now to overlap the latencies
+        ANKERL_UNORDERED_DENSE_PREFETCH(&m_values[value_idx_to_remove]);
+        ANKERL_UNORDERED_DENSE_PREFETCH(&m_values.back());
+
         erase_and_shift_down(bucket_idx);
         handle_erased_value(std::move(m_values[value_idx_to_remove]));
 
@@ -1410,6 +1445,7 @@ public:
                 m_buckets = std::move(other.m_buckets);
                 other.m_buckets.clear();
                 m_max_bucket_capacity = std::exchange(other.m_max_bucket_capacity, 0);
+                m_bucket_mask = std::exchange(other.m_bucket_mask, 0);
                 m_shifts = std::exchange(other.m_shifts, initial_shifts);
                 m_max_load_factor = std::exchange(other.m_max_load_factor, default_max_load_factor);
                 m_hash = std::exchange(other.m_hash, {});

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 #
 
 project('unordered_dense', 'cpp',
-    version: '4.8.1',
+    version: '4.9.0',
     license: 'MIT',
     default_options : [
         'cpp_std=c++17', 

--- a/test/app/counter.h
+++ b/test/app/counter.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <fmt/core.h> // for format_context, format_parse_context, format_to
+#include <fmt/format.h> // for format_context, format_parse_context, format_to
 
 #include <cstddef>     // for size_t
 #include <cstring>     // for memcmp

--- a/test/bench/copy.cpp
+++ b/test/bench/copy.cpp
@@ -3,7 +3,7 @@
 #include <third-party/nanobench.h> // for Rng, Bench
 
 #include <app/doctest.h> // for TestCase, skip, TEST_CASE, test_...
-#include <fmt/core.h>    // for format
+#include <fmt/format.h> // for format
 
 #include <cstddef>       // for size_t
 #include <cstdint>       // for uint64_t

--- a/test/bench/find_random.cpp
+++ b/test/bench/find_random.cpp
@@ -4,7 +4,7 @@
 #include <third-party/nanobench.h> // for Rng
 
 #include <app/doctest.h> // for TestCase, skip, ResultBuilder
-#include <fmt/core.h>    // for format, print
+#include <fmt/format.h> // for format, print
 
 #include <algorithm>     // for fill_n
 #include <array>         // for array

--- a/test/bench/game_of_life.cpp
+++ b/test/bench/game_of_life.cpp
@@ -3,7 +3,7 @@
 #include <app/counting_allocator.h>
 
 #include <app/doctest.h> // for TestCase, skip, ResultBuilder
-#include <fmt/core.h>    // for format, print
+#include <fmt/format.h> // for format, print
 
 #include <unordered_map>
 #include <vector>

--- a/test/bench/quick_overall_map.cpp
+++ b/test/bench/quick_overall_map.cpp
@@ -4,7 +4,7 @@
 #include <app/geomean.h>           // for geomean
 #include <third-party/nanobench.h> // for Rng, doNotOptimizeAway, Bench
 
-#include <fmt/core.h> // for print, format
+#include <fmt/format.h> // for print, format
 
 #include <chrono>        // for duration, operator-, high_resolu...
 #include <cstdint>       // for uint64_t

--- a/test/bench/swap.cpp
+++ b/test/bench/swap.cpp
@@ -2,7 +2,7 @@
 #include <app/doctest.h>            // for TestCase, skip, TEST_CASE, test_...
 #include <third-party/nanobench.h>  // for Rng, doNotOptimizeAway, Bench
 
-#include <fmt/core.h> // for format
+#include <fmt/format.h> // for format
 
 #include <cstddef>       // for size_t
 #include <cstdint>       // for uint64_t

--- a/test/unit/namespace.cpp
+++ b/test/unit/namespace.cpp
@@ -1,7 +1,7 @@
 #include <ankerl/unordered_dense.h>
 #include <app/doctest.h>
 
-namespace versioned_namespace = ankerl::unordered_dense::v4_8_1;
+namespace versioned_namespace = ankerl::unordered_dense::v4_9_0;
 
 static_assert(std::is_same_v<versioned_namespace::map<int, int>, ankerl::unordered_dense::map<int, int>>);
 static_assert(std::is_same_v<versioned_namespace::hash<int>, ankerl::unordered_dense::hash<int>>);

--- a/test/unit/pmr.cpp
+++ b/test/unit/pmr.cpp
@@ -2,7 +2,7 @@
 
 #include <app/doctest.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <cstddef>     // for size_t
 #include <cstdint>     // for uint64_t


### PR DESCRIPTION
Performance optimizations for the hot paths, keeping memory per node identical (buckets stay 8 bytes; the only addition is one per-*table* member). Verified with interleaved A/B runs of `bench_quick_overall_udm`: **~2-3% better geomean**, with `bench_find_random` −6 to −9% and `game_of_life` −3.5%. Also adds a CLAUDE.md documenting the build and benchmark workflow.

## Changes

- **wyhash: 96 bytes per iteration with 6 independent lanes** for inputs > 96 bytes (extra secret constants from rapidhash). Halves the serial multiply-chain depth: ~8% faster hashing of 200-byte keys, ~20% for 1000 bytes.
- **wyhash: independent tail lane** for inputs > 48 bytes. The finalization used two serial mixes, `mix(secret ^ len, mix(a ^ secret, b ^ seed))`; the tail is now mixed with secret constants only, so it doesn't depend on the seed chain and overlaps with the lane loops, and a single dependent mix finishes. Another ~7% off 200-byte hashing. Hash values change for inputs > 48 bytes; bit-flip avalanche verified statistically ideal (mean |bias| 0.098–0.101 vs 0.0997 theoretical) for lengths 49–500, zero collisions in 4M structured 200-byte keys.
- **Branchless bucket wraparound**: `next()` is now `(idx + 1) & m_bucket_mask` (bucket counts are always powers of two) instead of compare-and-branch against `bucket_count()`. The shift loops cache the mask in a local because `uint32` stores into the bucket array may alias a `uint32` member under strict aliasing, which forced per-iteration reloads. ~4-7% faster u64 find.
- **Erase prefetch**: `do_erase()` prefetches the erased and the last value row before the shift-down loop; both are needed right after it.

## Measurements

Per-benchmark (interleaved pairs, medians, noisy shared VM — worth re-checking on quiet hardware):

| benchmark | delta |
|---|---|
| u64 find | −4% to −7% |
| str find | −3% to −4% |
| str insert/erase | −3% |
| u64 insert/erase | 0% to −4% (phase-dependent) |
| iterate (u64/str) | neutral |

## Tried and rejected (measured, kept out)

- Early miss-exit in `do_find`'s unrolled probes: +26% on u64 find — the existing structure is right (third time it wins a bake-off).
- Fused single-branch probe / erase-style walk-while-less scans for find: +9% / +41% worse.
- absl-style SoA metadata split: mock kernel showed ~0.5% geomean upside for a large API-breaking refactor.
- SIMD group probing / SIMD hashing: not viable in the default baseline x86-64 build (SSE2 only), and probe chains (~1.3 buckets avg) are too short to amortize group scans.

## Testing

- All unit tests pass on clang 18 and gcc 13 release builds (422 cases, ~1.96M assertions).
- `clang-tidy` lint script and version lint pass; changed lines are clang-format clean.
- Header compiles warning-free (`-Wall -Wextra -Wconversion -Wold-style-cast -pedantic-errors -Werror`) at C++17/20/23 with gcc and clang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsBTDhrcuiKcEUL3fWBzUi