### PR TITLE
Stop running CI twice, and cover what it was not covering

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+
+# The actions in the workflows are pinned to floating major tags, so a bad release inside a major
+# version arrives silently. This does not fix that, but it makes the bumps visible and reviewable
+# instead of invisible.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,34 +1,280 @@
 name: Build, Test, Lint
 
-on: [push, pull_request]
+# Build pushes to main and any pull request. Previously this was "[push, pull_request]", which
+# ran all 28 jobs twice for a branch that has a PR open: once for the push and once for the
+# pull_request event.
+#
+# The weekly run is for a header-only library whose code stops changing while compilers keep
+# moving: it catches a new gcc, clang or standard library breaking us before someone has to
+# report it.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '23 5 * * 1'
 
+# A new push to a PR makes the previous run obsolete, so cancel it. Runs on main are never
+# cancelled, they are the ones the badge points at.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Nothing here writes to the repository.
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+env:
+  # Downloaded wrap tarballs land here, so the cache key only has to track the wrap files.
+  MESON_PACKAGE_CACHE: subprojects/packagecache
 
 # see https://github.com/mesonbuild/meson/blob/master/docs/markdown/Continuous-Integration.md
-# Note: I've moved MinGW & Windows to the top because they are the slowest
 jobs:
+
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - name: Cache APT packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
-          packages: clang-tidy
-          version: 1.0
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.x"
-          cache: "pip"
+          python-version: '3.x'
+      # Pinned, because .clang-tidy enables whole families and families gain checks in every
+      # release, so an unpinned clang-tidy turns a runner image bump into a red build for
+      # reasons that have nothing to do with a change. 18 is what ubuntu-latest happened to
+      # give us before this was pinned.
+      - run: sudo apt-get update && sudo apt-get install -y clang-tidy-18
       - run: ./scripts/lint/lint-version.py
+      # Checks that the header uses std:: qualified names, without which the C++ module build
+      # breaks. It lives in scripts/lint but no job ran it.
+      - run: ./scripts/lint/lint-stdint-types-modules.py
       - run: ./scripts/lint/lint-clang-tidy.py
+        env:
+          UNORDERED_DENSE_CLANG_TIDY: clang-tidy-18
 
+  # Linux, macOS, Windows, the sanitizers and the hardened build used to be four jobs repeating
+  # the same ten lines of checkout, python, cache and artifact setup. They differ only in the
+  # runner, the compiler and the meson arguments, which is what the matrix carries. The displayed
+  # job names are kept as they were so required checks and run history stay readable; "id" is the
+  # same thing without the characters a cache key may not contain.
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # One failing configuration should not hide the state of the others.
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux (gcc, C++17, 64bit)
+            id: linux-gcc-cpp17-64
+            os: ubuntu-latest
+            cxx: g++
+            apt: libboost-dev
+          - name: Linux (gcc, C++23, 64bit)
+            id: linux-gcc-cpp23-64
+            os: ubuntu-latest
+            cxx: g++
+            cpp_std: '23'
+            apt: libboost-dev
+          - name: Linux (clang, C++17, 64bit)
+            id: linux-clang-cpp17-64
+            os: ubuntu-latest
+            cxx: clang++
+            apt: libboost-dev
+          - name: Linux (clang, C++23, 64bit)
+            id: linux-clang-cpp23-64
+            os: ubuntu-latest
+            cxx: clang++
+            cpp_std: '23'
+            apt: libboost-dev
+
+          # A hash map that packs a bucket into 8 bytes and indexes with size_t is exactly the
+          # design a different word size breaks, so 32 bit is real coverage, not a formality.
+          # The runner images carry a 64 bit only toolchain, hence g++-multilib. -m32 used to be
+          # passed through CXXFLAGS, which meson folds into cpp_args anyway; saying it directly
+          # is what test/meson.build actually reads to pick the bundled fmt.
+          - name: Linux (gcc, C++17, 32bit)
+            id: linux-gcc-cpp17-32
+            os: ubuntu-latest
+            cxx: g++
+            apt: libboost-dev gcc-multilib g++-multilib
+            setup_args: -Dcpp_args=-m32 -Dcpp_link_args=-m32
+          - name: Linux (gcc, C++23, 32bit)
+            id: linux-gcc-cpp23-32
+            os: ubuntu-latest
+            cxx: g++
+            cpp_std: '23'
+            apt: libboost-dev gcc-multilib g++-multilib
+            setup_args: -Dcpp_args=-m32 -Dcpp_link_args=-m32
+          - name: Linux (clang, C++17, 32bit)
+            id: linux-clang-cpp17-32
+            os: ubuntu-latest
+            cxx: clang++
+            apt: libboost-dev gcc-multilib g++-multilib
+            setup_args: -Dcpp_args=-m32 -Dcpp_link_args=-m32
+          - name: Linux (clang, C++23, 32bit)
+            id: linux-clang-cpp23-32
+            os: ubuntu-latest
+            cxx: clang++
+            cpp_std: '23'
+            apt: libboost-dev gcc-multilib g++-multilib
+            setup_args: -Dcpp_args=-m32 -Dcpp_link_args=-m32
+
+          - name: macOS (C++17, arm64bit)
+            id: macos-cpp17
+            os: macos-latest
+            cxx: c++
+          - name: macOS (C++23, arm64bit)
+            id: macos-cpp23
+            os: macos-latest
+            cxx: c++
+            cpp_std: '23'
+
+          # ccache does not support MSVC, sccache does. Without this the windows jobs had no
+          # compiler cache at all and were by far the slowest.
+          - name: Windows (C++17, 64bit)
+            id: windows-cpp17-64
+            os: windows-latest
+            cxx: cl
+            msvc_arch: x64
+            ccache_variant: sccache
+            extra_artifacts: builddir/test/udm-test.exe
+          - name: Windows (C++latest, 64bit)
+            id: windows-cpplatest-64
+            os: windows-latest
+            cxx: cl
+            cpp_std: latest
+            msvc_arch: x64
+            ccache_variant: sccache
+            extra_artifacts: builddir/test/udm-test.exe
+          - name: Windows (C++17, 32bit)
+            id: windows-cpp17-32
+            os: windows-latest
+            cxx: cl
+            msvc_arch: x86
+            ccache_variant: sccache
+            extra_artifacts: builddir/test/udm-test.exe
+          - name: Windows (C++latest, 32bit)
+            id: windows-cpplatest-32
+            os: windows-latest
+            cxx: cl
+            cpp_std: latest
+            msvc_arch: x86
+            ccache_variant: sccache
+            extra_artifacts: builddir/test/udm-test.exe
+
+          # ARM64 is not an exotic target for this header: it has an ARM64EC carve-out, it
+          # assumes a little endian layout, and its hash reads 8 bytes at a time from possibly
+          # unaligned addresses. The old job was disabled over queue times and asked for a runner
+          # label that does not exist ("ubuntu-24.04-arm64"); the arm runners are free for public
+          # repositories now and the label is "ubuntu-24.04-arm".
+          - name: Linux ARM64 (gcc, C++17)
+            id: linux-arm64-gcc-cpp17
+            os: ubuntu-24.04-arm
+            cxx: g++
+            apt: libboost-dev
+          # The arm images carry a smaller toolset than the x64 ones, so clang is asked for
+          # explicitly rather than assumed.
+          - name: Linux ARM64 (clang, C++23)
+            id: linux-arm64-clang-cpp23
+            os: ubuntu-24.04-arm
+            cxx: clang++
+            cpp_std: '23'
+            apt: libboost-dev clang
+
+          # address and undefined are one leg per compiler rather than two: they compose, and the
+          # pair costs one build instead of two. halt_on_error is the point of running UBSan at
+          # all -- without it the runtime prints the error and the test still exits 0, so a green
+          # undefined-sanitizer leg meant very little.
+          - name: Linux Sanitizer (gcc, address+undefined)
+            id: linux-sanitize-gcc-asan-ubsan
+            os: ubuntu-latest
+            cxx: g++
+            apt: libboost-dev
+            setup_args: --buildtype=debugoptimized -Db_sanitize=address,undefined
+            asan_options: detect_stack_use_after_return=1:strict_string_checks=1
+            ubsan_options: print_stacktrace=1:halt_on_error=1
+          - name: Linux Sanitizer (clang, address+undefined)
+            id: linux-sanitize-clang-asan-ubsan
+            os: ubuntu-latest
+            cxx: clang++
+            apt: libboost-dev
+            setup_args: --buildtype=debugoptimized -Db_sanitize=address,undefined -Db_lundef=false
+            asan_options: detect_stack_use_after_return=1:strict_string_checks=1
+            ubsan_options: print_stacktrace=1:halt_on_error=1
+          - name: Linux Sanitizer (gcc, thread)
+            id: linux-sanitize-gcc-tsan
+            os: ubuntu-latest
+            cxx: g++
+            apt: libboost-dev
+            setup_args: --buildtype=debugoptimized -Db_sanitize=thread
+          - name: Linux Sanitizer (clang, thread)
+            id: linux-sanitize-clang-tsan
+            os: ubuntu-latest
+            cxx: clang++
+            apt: libboost-dev
+            setup_args: --buildtype=debugoptimized -Db_sanitize=thread -Db_lundef=false
+
+          # Builds with the hardening flags a distribution would use. _GLIBCXX_ASSERTIONS is the
+          # interesting one for a container: it turns on libstdc++'s precondition checks, so a
+          # bad iterator or index handed to a std type from inside the map is caught here.
+          - name: Linux Hardened (gcc, C++17, 64bit)
+            id: linux-hardened
+            os: ubuntu-latest
+            cxx: g++
+            apt: libboost-dev
+            setup_args: >-
+              --buildtype=debugoptimized
+              -Dcpp_args="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS
+              -fstack-protector-strong -fstack-clash-protection -fcf-protection=full
+              -Wformat -Wformat-security -Werror=format-security"
+              -Dcpp_link_args="-Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack"
+    steps:
+      - uses: actions/checkout@v7
+      - uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          variant: ${{ matrix.ccache_variant || 'ccache' }}
+          key: ${{ matrix.id }}
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.x'
+          cache: pip
+          cache-dependency-path: .github/workflows/requirements.txt
+      - uses: actions/cache@v6
+        with:
+          path: ${{ env.MESON_PACKAGE_CACHE }}
+          key: wraps-${{ hashFiles('subprojects/*.wrap') }}
+      - run: pip install -r .github/workflows/requirements.txt
+      - name: Install apt packages
+        if: matrix.apt
+        run: sudo apt-get update && sudo apt-get install -y ${{ matrix.apt }}
+      - uses: ilammy/msvc-dev-cmd@v1
+        if: matrix.msvc_arch
+        with:
+          arch: ${{ matrix.msvc_arch }}
+      # Every runner has to build against the same fmt. The macOS images ship a Homebrew fmt and
+      # the linux jobs used to apt-install libfmt-dev, while everything else fell back to the
+      # wrap, so three legs were testing against three different libraries. fmt is only test
+      # scaffolding, so pinning it to the wrap costs no coverage.
+      - run: meson setup builddir --force-fallback-for=fmt -Dcpp_std=c++${{ matrix.cpp_std || '17' }} ${{ matrix.setup_args }}
+        env:
+          CXX: ${{ matrix.ccache_variant || 'ccache' }} ${{ matrix.cxx }}
+      - run: meson test -C builddir --print-errorlogs
+        env:
+          ASAN_OPTIONS: ${{ matrix.asan_options }}
+          UBSAN_OPTIONS: ${{ matrix.ubsan_options }}
+      - uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: ${{ matrix.id }}-testlog
+          path: |
+            builddir/meson-logs/testlog.txt
+            ${{ matrix.extra_artifacts }}
+          retention-days: 7
+
+  # MinGW stays its own job: every step has to run inside the msys2 shell, and it brings its own
+  # compiler, python and meson rather than the ones the build job installs.
   mingw:
+    name: MinGW (C++${{ matrix.cxx_standard }}, ${{ matrix.arch_name }})
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -37,19 +283,18 @@ jobs:
         cxx_standard: [17, 23]
         include:
           - sys: mingw64
-            arch_name: "64bit"
+            arch_name: 64bit
             msystem: MINGW64
             prefix: mingw-w64-x86_64
           - sys: mingw32
-            arch_name: "32bit"
+            arch_name: 32bit
             msystem: MINGW32
             prefix: mingw-w64-i686
-    name: MinGW (C++${{ matrix.cxx_standard }}, ${{ matrix.arch_name }})
     defaults:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.msystem }}
@@ -63,301 +308,91 @@ jobs:
             ${{ matrix.prefix }}-ninja
             ${{ matrix.prefix }}-python
             ${{ matrix.prefix }}-python-pip
-      - name: Print compiler version
-        run: g++ --version
-      - run: meson setup builddir -Dcpp_std=c++${{ matrix.cxx_standard }}
-      - run: meson test -C builddir -v
-      - uses: actions/upload-artifact@v4
+      - uses: actions/cache@v6
+        with:
+          path: ${{ env.MESON_PACKAGE_CACHE }}
+          key: wraps-${{ hashFiles('subprojects/*.wrap') }}
+      - run: g++ --version
+      - run: meson setup builddir --force-fallback-for=fmt -Dcpp_std=c++${{ matrix.cxx_standard }}
+      - run: meson test -C builddir --print-errorlogs
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: MinGW_${{ matrix.arch_name }}_cpp${{ matrix.cxx_standard }}_Testlog
           path: builddir/meson-logs/testlog.txt
           retention-days: 7
 
-  windows:
-    runs-on: windows-latest
+  # The C++20 module build, which is CMake only. The two jobs this replaces uploaded meson logs
+  # from a build directory a CMake build never creates, and neither ever ran what it built:
+  # a module that compiles but does not link or start is not much of a check.
+  modules:
+    name: Modules (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        arch: [x64, x86]
-        cxx_standard: [17, latest]
         include:
-          - arch: x64
-            arch_name: "64bit"
-          - arch: x86
-            arch_name: "32bit"
-    name: Windows (C++${{ matrix.cxx_standard }}, ${{ matrix.arch_name }})
+          - name: clang, C++20, 64bit
+            os: ubuntu-latest
+            cxx: clang++
+          - name: MSVC, C++20, 64bit
+            os: windows-latest
+            cxx: cl
+            msvc_arch: x64
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
-          python-version: "3.x"
-          cache: "pip"
-      - run: pip install ninja meson
-      - uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: ${{ matrix.arch }}
-      - name: Print compiler version
-        run: cl
-      - run: meson setup builddir -Dcpp_std=c++${{ matrix.cxx_standard }}
-      - run: meson test -C builddir -v
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: Windows_${{ matrix.arch_name }}_cpp${{ matrix.cxx_standard }}_Testlog
-          path: |
-            builddir/meson-logs/testlog.txt
-            builddir/test/udm-test.exe
-          retention-days: 7
-
-  windows-module:
-    runs-on: windows-latest
-    name: Windows Modules (C++20, 64bit)
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.x"
-          cache: "pip"
-      - run: pip install ninja
-      - uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
+          python-version: '3.x'
+          cache: pip
+          cache-dependency-path: .github/workflows/requirements.txt
+      - run: pip install -r .github/workflows/requirements.txt
+      # CMake's C++ modules support needs a version the runner images do not necessarily carry.
+      - uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: '4.x'
-      - name: Print compiler version
-        run: cl
-      - run: cmake -G Ninja -DANKERL_ENABLE_EXAMPLE=TRUE -DANKERL_ENABLE_MODULES=TRUE -B build
-      - run: cmake --build build --verbose
-      - uses: actions/upload-artifact@v4
-        if: failure()
+      - uses: ilammy/msvc-dev-cmd@v1
+        if: matrix.msvc_arch
         with:
-          name: Windows_64bit_cpp23-modules_Testlog
-          path: |
-            builddir/meson-logs/testlog.txt
-            builddir/test/udm-test.exe
-          retention-days: 7
-
-  macos:
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        cxx_standard: [17, 23]
-    name: macOS (C++${{ matrix.cxx_standard }}, arm64bit)
-    steps:
-      - uses: actions/checkout@v5
-      - uses: hendrikmuhs/ccache-action@v1.2.19
-        with:
-          key: clang-cpp${{ matrix.cxx_standard }}-arm64bit
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.x"
-          cache: "pip"
-      - run: brew install gcc ccache meson ninja
-      - name: Print compiler versions
-        run: c++ --version
-      - run: meson setup builddir/ -Dcpp_std=c++${{ matrix.cxx_standard }}
-        env:
-          CXX: ccache c++
-      - run: meson test -C builddir/ -v
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: MacOS_cpp${{ matrix.cxx_standard }}_Meson_Testlog
-          path: builddir/meson-logs/testlog.txt
-          retention-days: 7
-
-  linux:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        compiler: [gcc, clang]
-        cxx_standard: [17, 23]
-        arch: [64, 32]
-        include:
-          - compiler: gcc
-            cc: gcc
-            cxx: g++
-          - compiler: clang
-            cc: clang
-            cxx: clang++
-          - arch: 64
-            arch_flags: ""
-            packages: libboost-dev libfmt-dev ccache
-          - arch: 32
-            arch_flags: "-m32"
-            packages: "libboost-dev gcc-multilib g++-multilib"
-    name: Linux (${{ matrix.compiler }}, C++${{ matrix.cxx_standard }}, ${{ matrix.arch }}bit)
-    steps:
-      - uses: actions/checkout@v5
-      - name: Cache APT packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: ${{ matrix.packages }} ccache
-          version: 1.0
-      - uses: hendrikmuhs/ccache-action@v1.2.19
-        with:
-          key: ${{ matrix.compiler }}-cpp${{ matrix.cxx_standard }}-${{ matrix.arch }}bit
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.x"
-          cache: "pip"
-      - run: pip install meson ninja
-      - name: Print compiler versions
-        run: |
-          ${{ matrix.cc }} --version
-          ${{ matrix.cxx }} --version
-      - run: meson setup builddir/ -Dcpp_std=c++${{ matrix.cxx_standard }}
-        env:
-          CC: ccache ${{ matrix.cc }}
-          CXX: ccache ${{ matrix.cxx }}
-          CFLAGS: ${{ matrix.arch_flags }}
-          CXXFLAGS: ${{ matrix.arch_flags }}
-          LDFLAGS: ${{ matrix.arch_flags }}
-      - run: meson test -C builddir/ -v
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: Linux_${{ matrix.compiler }}_cpp${{ matrix.cxx_standard }}_${{ matrix.arch }}bit_Testlog
-          path: builddir/meson-logs/testlog.txt
-          retention-days: 7
-
-  linux-modules:
-    runs-on: ubuntu-latest
-    name: Linux Modules (clang, C++20, 64bit)
-    steps:
-      - uses: actions/checkout@v5
-      - name: Cache APT packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libboost-dev libfmt-dev
-          version: 1.0
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.x"
-          cache: "pip"
-      - run: pip install ninja
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v2
-        with:
-          cmake-version: '4.x'
-      - name: Print compiler versions
-        run: |
-          clang --version
-          clang++ --version
+          arch: ${{ matrix.msvc_arch }}
       - run: cmake -G Ninja -DANKERL_ENABLE_EXAMPLE=TRUE -DANKERL_ENABLE_MODULES=TRUE -B build
         env:
-          CC: clang
-          CXX: clang++
-          CFLAGS: -m64
-          CXXFLAGS: -m64
-          LDFLAGS: -m64
+          CXX: ${{ matrix.cxx }}
       - run: cmake --build build --verbose
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: Linux_clang_cpp23-modules_64bit_Testlog
-          path: builddir/meson-logs/testlog.txt
-          retention-days: 7
+      # The example is the only consumer of the module, so running it is the only thing that
+      # says the module actually works.
+      - run: ./build/example
+        shell: bash
 
-  linux-sanitizers:
+  # CMakeLists.txt is what most consumers actually use, and nothing else in CI configures it
+  # without the module options. The install, export and package-config half of it was never
+  # built by any job at all. See test/cmake_consumer.
+  cmake-consumer:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        compiler: [gcc, clang]
-        sanitizer: [address, thread, undefined]
-        include:
-          - compiler: gcc
-            cc: gcc
-            cxx: g++
-          - compiler: clang
-            cc: clang
-            cxx: clang++
-          - sanitizer: address
-            sanitizer_flags: "-fsanitize=address -fno-omit-frame-pointer"
-          - sanitizer: thread
-            sanitizer_flags: "-fsanitize=thread"
-          - sanitizer: undefined
-            sanitizer_flags: "-fsanitize=undefined"
-    name: Linux Sanitizer (${{ matrix.compiler }}, ${{ matrix.sanitizer }})
     steps:
-      - uses: actions/checkout@v5
-      - name: Cache APT packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libboost-dev libfmt-dev ccache
-          version: 1.0
-      - uses: hendrikmuhs/ccache-action@v1.2.19
-        with:
-          key: ${{ matrix.compiler }}-sanitize-${{ matrix.sanitizer }}
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.x"
-          cache: "pip"
-      - run: pip install meson ninja
-      - name: Print compiler versions
+      - uses: actions/checkout@v7
+      - name: add_subdirectory
         run: |
-          ${{ matrix.cc }} --version
-          ${{ matrix.cxx }} --version
-      - run: meson setup builddir/ -Dcpp_std=c++17 -Db_sanitize=${{ matrix.sanitizer }}
-        env:
-          CC: ccache ${{ matrix.cc }}
-          CXX: ccache ${{ matrix.cxx }}
-      - run: meson test -C builddir/ -v
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: Linux_${{ matrix.compiler }}_sanitize_${{ matrix.sanitizer }}_Testlog
-          path: builddir/meson-logs/testlog.txt
-          retention-days: 7
-
-  linux-arm64:
-    runs-on: ubuntu-24.04-arm64
-    if: false # Disabled for now due to long queue times
-    strategy:
-      fail-fast: false
-      matrix:
-        compiler: [gcc, clang]
-        cxx_standard: [17, 23]
-        include:
-          - compiler: gcc
-            cc: gcc
-            cxx: g++
-          - compiler: clang
-            cc: clang
-            cxx: clang++
-    name: Linux ARM64 (${{ matrix.compiler }}, C++${{ matrix.cxx_standard }})
-    steps:
-      - uses: actions/checkout@v5
-      - name: Cache APT packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libboost-dev libfmt-dev ccache
-          version: 1.0
-      - uses: hendrikmuhs/ccache-action@v1.2.19
-        with:
-          key: arm64-${{ matrix.compiler }}-cpp${{ matrix.cxx_standard }}
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.x"
-          cache: "pip"
-      - run: pip install meson ninja
-      - name: Print compiler versions
+          cmake -S test/cmake_consumer -B builddir-cmake
+          cmake --build builddir-cmake
+          ./builddir-cmake/consumer
+      - name: install
         run: |
-          ${{ matrix.cc }} --version
-          ${{ matrix.cxx }} --version
-      - run: meson setup builddir/ -Dcpp_std=c++${{ matrix.cxx_standard }}
-        env:
-          CC: ccache ${{ matrix.cc }}
-          CXX: ccache ${{ matrix.cxx }}
-      - run: meson test -C builddir/ -v
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: Linux_ARM64_${{ matrix.compiler }}_cpp${{ matrix.cxx_standard }}_Testlog
-          path: builddir/meson-logs/testlog.txt
-          retention-days: 7
+          cmake -S . -B builddir-install -DCMAKE_INSTALL_PREFIX="$PWD/prefix"
+          cmake --build builddir-install --target install
+      # Asking for major version 4 rather than the exact one, so this does not need editing on
+      # every release. SameMajorVersion is the compatibility the generated config declares.
+      - name: find_package
+        run: |
+          cmake -S test/cmake_consumer/installed -B builddir-find \
+            -DCMAKE_PREFIX_PATH="$PWD/prefix" -DUNORDERED_DENSE_REQUIRED_VERSION=4
+          cmake --build builddir-find
+          ./builddir-find/consumer-installed
+      # The happy path passing says nothing about whether the version is actually checked.
+      - name: a version that is not installed has to be refused
+        run: |
+          if cmake -S test/cmake_consumer/installed -B builddir-badver \
+              -DCMAKE_PREFIX_PATH="$PWD/prefix" -DUNORDERED_DENSE_REQUIRED_VERSION=99 >/dev/null 2>&1; then
+            echo "::error::find_package accepted version 99, so it is not checking versions"
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+# A tag is the one thing here that is genuinely hard to take back: deleting a pushed tag does not
+# delete it from the clones that already fetched it, and this repository is vendored by name and
+# tag all over the place. So the checks that a release is what it claims to be belong at tag
+# push, before anyone builds from it.
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+env:
+  MESON_PACKAGE_CACHE: subprojects/packagecache
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The ancestor check below needs main and the history connecting it to the tag.
+          fetch-depth: 0
+
+      # lint-version.py already checks the header, CMakeLists.txt, meson.build, stl.h and the
+      # namespace test against each other, on every run. What nothing checks is whether the tag
+      # agrees with them. The release convention is to tag the "bump version to X.Y.Z" commit,
+      # which by then is often no longer the tip of main, so this is easy to get wrong by hand.
+      - name: Tag matches the version in the tagged commit
+        run: ./scripts/lint/lint-version.py --expect "${GITHUB_REF_NAME#v}"
+
+      - name: Tagged commit is on main
+        run: |
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor HEAD FETCH_HEAD; then
+            echo "::error::${GITHUB_REF_NAME} points at a commit that is not on main."
+            exit 1
+          fi
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.x'
+          cache: pip
+          cache-dependency-path: .github/workflows/requirements.txt
+      - uses: actions/cache@v6
+        with:
+          path: ${{ env.MESON_PACKAGE_CACHE }}
+          key: wraps-${{ hashFiles('subprojects/*.wrap') }}
+      - run: pip install -r .github/workflows/requirements.txt
+
+      # main.yml has already built this commit in every configuration, since the tag is on main.
+      # This is here so a release cannot be cut from a commit that was never actually run.
+      - run: meson setup builddir --force-fallback-for=fmt
+      - run: meson test -C builddir --print-errorlogs
+      - uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: release-meson-testlog
+          path: builddir/meson-logs/testlog.txt

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,0 +1,5 @@
+# Build tools for the CI jobs. Pinned so actions/setup-python's pip cache key is stable and pip
+# does not have to resolve anything against PyPI on every run. The requirements.txt in the root
+# is the unpinned one, for developers.
+meson==1.11.2
+ninja==1.13.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,20 @@ meson test -C builddir/clang_release unit --verbose
 ./builddir/clang_release/test/udm-test
 ```
 
+## CI
+
+`.github/workflows/main.yml` builds every leg the same way, so any of them reproduces locally:
+
+```sh
+meson setup builddir --force-fallback-for=fmt -Dcpp_std=c++17 <matrix setup_args>
+meson test -C builddir --print-errorlogs
+```
+
+`--force-fallback-for=fmt` is what makes every runner build against the vendored fmt instead of
+whatever the machine happens to have installed. Linters (`scripts/lint/lint-*.py`) run in the
+`lint` job, against a pinned `clang-tidy-18` — `lint-clang-format.py` is deliberately *not* run
+there yet, the tree does not satisfy it.
+
 ## Notes for sandboxed / offline environments
 
 If meson cannot download the wrap subprojects (e.g. GitHub release tarballs blocked), fetch the doctest and fmt sources manually into `subprojects/doctest-2.4.12/` and `subprojects/fmt-11.2.0/` (matching the `directory` field of the `.wrap` files) with a minimal `meson.build` in each that declares `doctest_dep` (header-only, include dir `doctest/`) and `fmt_dep` (include dir `include/`, sources `src/format.cc`, `src/os.cc`) and calls `meson.override_dependency()`. Meson skips the download when the subproject directory already exists. These directories are gitignored — do not commit them.

--- a/scripts/lint/lint-clang-tidy.py
+++ b/scripts/lint/lint-clang-tidy.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import os
 import shutil
 from subprocess import run
 import sys
@@ -12,10 +13,19 @@ def main():
         )
     )
     p.add_argument("--std", default="c++17", help="C++ standard (default: c++17)")
+    p.add_argument(
+        "--binary",
+        default=os.environ.get("UNORDERED_DENSE_CLANG_TIDY", "clang-tidy"),
+        help=(
+            "clang-tidy to run, also settable via UNORDERED_DENSE_CLANG_TIDY. CI pins a "
+            "version here: .clang-tidy enables whole families, families gain checks in every "
+            "release, so an unpinned clang-tidy turns a toolchain bump into a red build."
+        ),
+    )
     args = p.parse_args()
 
-    if not (clang_tidy := shutil.which("clang-tidy")):
-        print("Error: clang-tidy not found in PATH", file=sys.stderr)
+    if not (clang_tidy := shutil.which(args.binary)):
+        print(f"Error: {args.binary} not found in PATH", file=sys.stderr)
         raise SystemExit(1)
 
     # Exit with clang-tidy's exit code.

--- a/scripts/lint/lint-version.py
+++ b/scripts/lint/lint-version.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python3
+"""Check that every file repeating the version agrees with the ANKERL_UNORDERED_DENSE_VERSION_*
+macros in unordered_dense.h, which are the reference.
+
+With --expect it also checks that reference against a version passed in. That is how the release
+workflow ties a pushed tag to what the tagged commit actually contains: the files agreeing with
+each other says nothing about whether v4.9.0 was put on the commit that says 4.9.0."""
+
+import argparse
 from pathlib import Path
 import re
 
@@ -25,8 +33,22 @@ def read_version_from_header(p: Path) -> str:
 
 
 def main():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--expect",
+        default=None,
+        metavar="X.Y.Z",
+        help="also require this exact version, e.g. 4.9.0",
+    )
+    args = p.parse_args()
+
     ref = read_version_from_header(HEADER)
     errs = []
+    if args.expect is not None and args.expect != ref:
+        errs.append(f"ERROR: expected version {args.expect}, but {HEADER} says {ref}")
+
     for path, pattern, count in CHECKS:
         matches = list(re.finditer(pattern, path.read_text(), re.M))
         if (n := len(matches)) != count:

--- a/test/cmake_consumer/CMakeLists.txt
+++ b/test/cmake_consumer/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.12)
+project("unordered_dense-cmake-consumer" CXX)
+
+# Consume unordered_dense the way a downstream project does that vendors the sources. Nothing
+# else in CI configures CMakeLists.txt without ANKERL_ENABLE_MODULES, so a typo in the interface
+# target's include directories or in its compile features would otherwise ship unnoticed.
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../.." unordered_dense)
+
+add_executable(consumer main.cpp)
+target_link_libraries(consumer PRIVATE unordered_dense::unordered_dense)

--- a/test/cmake_consumer/installed/CMakeLists.txt
+++ b/test/cmake_consumer/installed/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.12)
+project("unordered_dense-find-package-consumer" CXX)
+
+# Consume unordered_dense the way someone does after `cmake --install`, or the way a
+# distribution's package expects to be used. Point CMAKE_PREFIX_PATH at the install prefix.
+#
+# UNORDERED_DENSE_REQUIRED_VERSION exists so CI can also check that a version that is not there
+# is actually refused, rather than only checking the happy path.
+set(UNORDERED_DENSE_REQUIRED_VERSION "" CACHE STRING "version to demand from find_package")
+
+find_package(unordered_dense ${UNORDERED_DENSE_REQUIRED_VERSION} CONFIG REQUIRED)
+
+add_executable(consumer-installed ../main.cpp)
+target_link_libraries(consumer-installed PRIVATE unordered_dense::unordered_dense)

--- a/test/cmake_consumer/main.cpp
+++ b/test/cmake_consumer/main.cpp
@@ -1,0 +1,24 @@
+#include <ankerl/unordered_dense.h>
+
+#include <cstdio>
+#include <string>
+
+// Shared by both consumer projects here, the add_subdirectory one and the find_package one.
+// Deliberately shallow: this checks that the CMake target carries the include directory and the
+// C++17 requirement, not that the map behaves. The meson suite owns behaviour.
+auto main() -> int {
+    auto map = ankerl::unordered_dense::map<std::string, int>();
+    for (int i = 0; i < 100; ++i) {
+        map[std::to_string(i)] = i;
+    }
+    map.erase("7");
+    if (map.size() != 99 || map.at("99") != 99 || map.contains("7")) {
+        return 1;
+    }
+
+    std::printf("consumed unordered_dense %d.%d.%d through CMake\n",
+                ANKERL_UNORDERED_DENSE_VERSION_MAJOR,
+                ANKERL_UNORDERED_DENSE_VERSION_MINOR,
+                ANKERL_UNORDERED_DENSE_VERSION_PATCH);
+    return 0;
+}


### PR DESCRIPTION
Takes the ideas from svector's recently refactored CI and applies them here.

## Half the runs

`on: [push, pull_request]` built all 28 jobs twice for any branch with a PR open: once for the push, once for the pull_request event. Now it builds pushes to `main` and pull requests, cancels superseded PR runs, and adds a weekly run — this is a header-only library whose code stops changing while compilers keep moving, so a new gcc, clang or standard library breaking it should be found here rather than reported.

## One matrix instead of four jobs

Linux, macOS, Windows, the sanitizers and the hardened build were four jobs repeating the same ten lines of checkout, python, cache and artifact setup. They differ in the runner, the compiler and the meson arguments, so that is what the matrix carries. The displayed job names are unchanged so run history stays readable; the `id` field is the same name without the characters a cache key may not contain. MinGW stays its own job — every step of it has to run inside the msys2 shell.

## Gaps that consolidating exposed

- **Each leg built against a different fmt**: apt `libfmt-dev` on Linux, Homebrew's on macOS, the wrap everywhere else. `--force-fallback-for=fmt` makes it the vendored one everywhere. fmt is only test scaffolding, so no coverage is lost. (This is what broke a leg in svector, inside fmt's own headers.)
- **The undefined-sanitizer legs printed their findings and exited 0.** `halt_on_error=1` makes them fail. address and undefined now share one leg per compiler: they compose, and it is one build instead of two.
- **Nothing built the install, export and package-config half of `CMakeLists.txt`**, which is how most consumers use this. The new `cmake-consumer` job builds it through `add_subdirectory` and through `find_package` from an install prefix, and checks that a version that is *not* installed is refused — the happy path passing says nothing about whether the version is checked.
- **The modules jobs never ran what they built**, and uploaded meson logs from a directory a CMake build does not create. They are one job now, and it runs the example.
- **The ARM64 job asked for a runner label that does not exist** (`ubuntu-24.04-arm64`) and was disabled on top of that. This header has an ARM64EC carve-out, assumes little endian, and reads 8 bytes at a time from possibly unaligned addresses, so it is worth a leg: `ubuntu-24.04-arm`, gcc and clang.
- **New hardened leg** with the flags a distribution builds with. `_GLIBCXX_ASSERTIONS` is the one that matters for a container: it turns on libstdc++'s precondition checks.
- **`lint-stdint-types-modules.py` existed but no job ran it.**

## Faster, on top of halving the runs

sccache on the Windows legs, which had no compiler cache at all and were the slowest; the downloaded wrap tarballs cached on the wrap files' hash; no more `brew install gcc` for a compiler nothing used.

## Pinned what was floating

meson and ninja in `.github/workflows/requirements.txt`; clang-tidy at 18, which is what `ubuntu-latest` was giving us anyway, so a runner image bump cannot enable whole new check families under us; the actions at majors, with a `dependabot.yml` so those bumps are visible and reviewable. Dropped `cache-apt-pkgs-action@latest`, a floating tag pointing at a third-party action.

## Release checks

New `release.yml`: at tag push, the tag is checked against the version in the commit it points at (`lint-version.py` gained `--expect`), that commit is checked to be on `main`, and the suite is run. Deleting a pushed tag does not delete it from the clones that already fetched it, so these checks belong at tag push.

## Verified locally

Baseline gcc C++17, gcc and clang C++23 against the wrap fmt, the hardened leg, gcc address+undefined with `halt_on_error`, all four cmake-consumer steps, and the lint scripts. Clang's sanitizer runtime is not installed in the machine this was written on, so that one leg is config-only.

## Deliberately not included

`scripts/lint/lint-clang-format.py` still does not run in CI: it fails on 8 files including `unordered_dense.h` itself, and it has a bug — `SystemExit(ec)` is constructed but never raised, so `scripts/lint/all.py` reports it green regardless. Fixing that means reformatting the header, which does not belong in a CI change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxhyeMXim7Pvb8SmYoEdBk)_