### PR TITLE
Four fixes: extract(), max_load_factor, noexcept specifications, swap()

### DIFF
--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1446,9 +1446,12 @@ public:
         return *this;
     }
 
-    auto operator=(table&& other) noexcept(noexcept(std::is_nothrow_move_assignable_v<value_container_type> &&
-                                                    std::is_nothrow_move_assignable_v<Hash> &&
-                                                    std::is_nothrow_move_assignable_v<KeyEqual>)) -> table& {
+    // The condition used to be wrapped in another noexcept(), which asks whether evaluating a bool expression can
+    // throw. It cannot, so the specification was noexcept(true) whatever the traits said, and a type with a throwing
+    // move assignment terminated instead of propagating.
+    auto operator=(table&& other) noexcept(std::is_nothrow_move_assignable_v<value_container_type> &&
+                                           std::is_nothrow_move_assignable_v<Hash> &&
+                                           std::is_nothrow_move_assignable_v<KeyEqual>) -> table& {
         if (&other != this) {
             deallocate_buckets(); // deallocate before m_values is set (might have another allocator)
             m_values = std::move(other.m_values);
@@ -1944,8 +1947,8 @@ public:
         return tmp;
     }
 
-    void swap(table& other) noexcept(noexcept(std::is_nothrow_swappable_v<value_container_type> &&
-                                              std::is_nothrow_swappable_v<Hash> && std::is_nothrow_swappable_v<KeyEqual>)) {
+    void swap(table& other) noexcept(std::is_nothrow_swappable_v<value_container_type> &&
+                                     std::is_nothrow_swappable_v<Hash> && std::is_nothrow_swappable_v<KeyEqual>) {
         using std::swap;
         swap(other, *this);
     }

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1949,8 +1949,18 @@ public:
 
     void swap(table& other) noexcept(std::is_nothrow_swappable_v<value_container_type> &&
                                      std::is_nothrow_swappable_v<Hash> && std::is_nothrow_swappable_v<KeyEqual>) {
+        // There is no free swap() for table, so "swap(other, *this)" used to resolve to the generic std::swap: three
+        // move assignments, each of which hands the moved-from table a freshly allocated set of buckets. That is three
+        // allocations for an operation that needs none, and three ways to throw out of a noexcept function.
         using std::swap;
-        swap(other, *this);
+        swap(m_values, other.m_values);
+        swap(m_buckets, other.m_buckets);
+        swap(m_max_bucket_capacity, other.m_max_bucket_capacity);
+        swap(m_bucket_mask, other.m_bucket_mask);
+        swap(m_max_load_factor, other.m_max_load_factor);
+        swap(m_hash, other.m_hash);
+        swap(m_equal, other.m_equal);
+        swap(m_shifts, other.m_shifts);
     }
 
     // lookup /////////////////////////////////////////////////////////////////
@@ -2161,6 +2171,12 @@ public:
 
     friend auto operator!=(table const& a, table const& b) -> bool {
         return !(a == b);
+    }
+
+    // Standard containers provide this, and generic code written as "using std::swap; swap(a, b);" needs it to find
+    // the member. Without it that call lands on the generic std::swap and moves three times.
+    friend void swap(table& a, table& b) noexcept(noexcept(a.swap(b))) {
+        a.swap(b);
     }
 };
 

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -2078,7 +2078,11 @@ public:
     }
 
     void max_load_factor(float ml) {
-        m_max_load_factor = ml;
+        // A load factor above 1 is meaningful for a container that chains, and std::unordered_map takes one. Open
+        // addressing cannot use it: m_max_bucket_capacity would exceed bucket_count(), is_full() would never fire, the
+        // table would fill completely, and place_and_shift_up() would then probe forever for an empty bucket that does
+        // not exist. Exactly 1 is fine, because is_full() is checked after the value is appended.
+        m_max_load_factor = (std::min)(ml, 1.0F);
         if (bucket_count() != max_bucket_count()) {
             m_max_bucket_capacity = static_cast<value_idx_type>(static_cast<float>(bucket_count()) * max_load_factor());
         }

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1587,7 +1587,14 @@ public:
     // nonstandard API: *this is emptied.
     // Also see "A Standard flat_map" https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0429r9.pdf
     auto extract() && -> value_container_type {
-        return std::move(m_values);
+        auto values = std::move(m_values);
+
+        // Moving the values out does not empty the buckets, and they index into the container that just left. Emptying
+        // them here is what makes "*this is emptied" true: without it the table looks empty -- size() is 0, find()
+        // returns end() -- and then the next insert probes a bucket pointing at an element that is no longer there.
+        m_values.clear();
+        clear_buckets();
+        return values;
     }
 
     // nonstandard API:

--- a/test/meson.build
+++ b/test/meson.build
@@ -60,6 +60,7 @@ test_sources = [
     'unit/move_to_moved.cpp',
     'unit/multiple_apis.cpp',
     'unit/namespace.cpp',
+    'unit/noexcept_contract.cpp',
     'unit/not_copyable.cpp',
     'unit/not_moveable.cpp',
     'unit/pmr_move_with_allocators.cpp',

--- a/test/unit/extract.cpp
+++ b/test/unit/extract.cpp
@@ -27,6 +27,32 @@ TEST_CASE_MAP("extract", counter::obj, counter::obj) {
     }
 }
 
+// extract() documents that *this is emptied, and size() and find() agree with that, so a map that has been extracted
+// from has to actually be usable again. It wasn't: the buckets still indexed into the container that had just left.
+TEST_CASE_MAP("extract_leaves_a_usable_map", int, int) {
+    auto map = map_t();
+    for (int i = 0; i < 100; ++i) {
+        map[i] = i;
+    }
+
+    auto container = std::move(map).extract();
+    REQUIRE(container.size() == 100U);
+    REQUIRE(map.empty());
+    REQUIRE(map.size() == 0U);
+    REQUIRE(map.find(0) == map.end());
+
+    // refill it with keys that hash to the buckets the extracted elements used
+    for (int i = 0; i < 200; ++i) {
+        map[i] = i + 1;
+    }
+    REQUIRE(map.size() == 200U);
+    for (int i = 0; i < 200; ++i) {
+        auto it = map.find(i);
+        REQUIRE(it != map.end());
+        REQUIRE(it->second == i + 1);
+    }
+}
+
 TEST_CASE_MAP("extract_element", counter::obj, counter::obj) {
     auto counts = counter();
     INFO(counts);

--- a/test/unit/load_factor.cpp
+++ b/test/unit/load_factor.cpp
@@ -13,3 +13,30 @@ TEST_CASE_MAP("load_factor", int, int) {
         REQUIRE(m.load_factor() <= 0.8F);
     }
 }
+
+// A load factor above 1 used to be accepted and then hang: the table filled completely and the next insert probed
+// forever for an empty bucket. It is clamped now, so this test finishes rather than spinning.
+TEST_CASE_MAP("max_load_factor_above_one_is_clamped", int, int) {
+    auto m = map_t();
+    m.max_load_factor(2.0F);
+    REQUIRE(m.max_load_factor() <= 1.0F);
+
+    // 1.0 means every bucket is used before the table grows, so this walks the completely full table at every size
+    for (int i = 0; i < 10000; ++i) {
+        m.emplace(i, i);
+        REQUIRE(m.load_factor() <= 1.0F);
+    }
+    REQUIRE(m.size() == 10000U);
+    for (int i = 0; i < 10000; ++i) {
+        REQUIRE(m.find(i) != m.end());
+    }
+
+    // and the same table has to survive erasing, which shifts buckets down
+    for (int i = 0; i < 10000; i += 2) {
+        REQUIRE(m.erase(i) == 1U);
+    }
+    REQUIRE(m.size() == 5000U);
+    for (int i = 1; i < 10000; i += 2) {
+        REQUIRE(m.find(i) != m.end());
+    }
+}

--- a/test/unit/noexcept_contract.cpp
+++ b/test/unit/noexcept_contract.cpp
@@ -1,0 +1,65 @@
+#include <ankerl/unordered_dense.h>
+
+#include <app/doctest.h>
+
+#include <cstdint>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace {
+
+// A hasher that is fine to copy but whose move operations can throw. Everything else about the map stays the default,
+// so any potentially-throwing operation the map reports has to come from here.
+struct throwing_hash {
+    using is_avalanching = void;
+
+    throwing_hash() = default;
+    throwing_hash(throwing_hash const&) = default;
+    throwing_hash(throwing_hash&& /*other*/) noexcept(false) {} // NOLINT(performance-noexcept-move-constructor)
+    auto operator=(throwing_hash const&) -> throwing_hash& = default;
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    auto operator=(throwing_hash&& /*other*/) noexcept(false) -> throwing_hash& {
+        return *this;
+    }
+    ~throwing_hash() = default;
+
+    auto operator()(int x) const -> std::uint64_t {
+        return static_cast<std::uint64_t>(x);
+    }
+};
+
+using plain_map = ankerl::unordered_dense::map<int, int>;
+using throwing_map = ankerl::unordered_dense::map<int, int, throwing_hash>;
+
+// The everyday map keeps the strong guarantees callers rely on: std::vector<map> has to move its elements on growth
+// rather than copy them, and that only happens when the move assignment is noexcept.
+static_assert(std::is_nothrow_move_assignable_v<plain_map>);
+static_assert(noexcept(std::declval<plain_map&>().swap(std::declval<plain_map&>())));
+
+// ...and a map whose hasher can throw has to say so. These were both noexcept(true) regardless, because the condition
+// sat inside another noexcept(), which only ever asks whether evaluating a bool can throw.
+static_assert(!std::is_nothrow_move_assignable_v<throwing_hash>);
+static_assert(!std::is_nothrow_move_assignable_v<throwing_map>);
+static_assert(!std::is_nothrow_swappable_v<throwing_hash>);
+static_assert(!noexcept(std::declval<throwing_map&>().swap(std::declval<throwing_map&>())));
+
+} // namespace
+
+// The static_asserts above are the test; this only makes the translation unit do something at runtime, and checks that
+// a map with such a hasher is otherwise perfectly usable.
+TEST_CASE("noexcept_contract") {
+    auto a = throwing_map();
+    for (int i = 0; i < 100; ++i) {
+        a[i] = i;
+    }
+
+    auto b = throwing_map();
+    a.swap(b);
+    REQUIRE(a.empty());
+    REQUIRE(b.size() == 100U);
+
+    auto c = std::move(b);
+    REQUIRE(c.size() == 100U);
+    REQUIRE(c.find(42) != c.end());
+}

--- a/test/unit/swap.cpp
+++ b/test/unit/swap.cpp
@@ -4,6 +4,9 @@
 #include <app/doctest.h>
 #include <app/print.h>
 
+#include <cstddef>
+#include <memory>
+#include <utility>
 #include <vector>
 
 TEST_CASE_MAP("swap", int, int) {
@@ -49,4 +52,80 @@ TEST_CASE_MAP("swap", int, int) {
         }
         REQUIRE(a.end() == a.find(1));
     }
+}
+
+namespace {
+
+size_t g_num_allocations = 0; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+// Stateless, so it stays default constructible and every instance compares equal: this counts allocations without
+// changing anything else about how the map behaves.
+template <typename T>
+struct allocation_counting_allocator {
+    using value_type = T;
+
+    allocation_counting_allocator() = default;
+
+    template <typename U>
+    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+    allocation_counting_allocator(allocation_counting_allocator<U> const& /*other*/) noexcept {}
+
+    auto allocate(size_t n) -> T* {
+        ++g_num_allocations;
+        return std::allocator<T>{}.allocate(n);
+    }
+
+    void deallocate(T* p, size_t n) noexcept {
+        std::allocator<T>{}.deallocate(p, n);
+    }
+};
+
+template <typename T, typename U>
+auto operator==(allocation_counting_allocator<T> const& /*a*/, allocation_counting_allocator<U> const& /*b*/) noexcept
+    -> bool {
+    return true;
+}
+
+template <typename T, typename U>
+auto operator!=(allocation_counting_allocator<T> const& /*a*/, allocation_counting_allocator<U> const& /*b*/) noexcept
+    -> bool {
+    return false;
+}
+
+} // namespace
+
+// swap() went through the generic std::swap, so it move-assigned three times and each of those handed the moved-from
+// map a fresh set of buckets. Exchanging what two maps already own needs no allocation at all.
+TEST_CASE("swap_does_not_allocate") {
+    using map_t = ankerl::unordered_dense::map<int,
+                                               int,
+                                               ankerl::unordered_dense::hash<int>,
+                                               std::equal_to<int>,
+                                               allocation_counting_allocator<std::pair<int, int>>>;
+
+    auto a = map_t();
+    auto b = map_t();
+    for (int i = 0; i < 1000; ++i) {
+        a[i] = i;
+    }
+    for (int i = 0; i < 10; ++i) {
+        b[i] = -i;
+    }
+
+    g_num_allocations = 0;
+    a.swap(b);
+    REQUIRE(g_num_allocations == 0);
+
+    REQUIRE(a.size() == 10U);
+    REQUIRE(b.size() == 1000U);
+    REQUIRE(a.at(5) == -5);
+    REQUIRE(b.at(5) == 5);
+
+    // and back again through the ADL form generic code uses, which now finds the member
+    using std::swap;
+    swap(a, b);
+    REQUIRE(g_num_allocations == 0);
+    REQUIRE(a.size() == 1000U);
+    REQUIRE(b.size() == 10U);
+    REQUIRE(a.at(999) == 999);
 }


### PR DESCRIPTION
Four independent bugs found while reading the header, one commit each. Every one has a test that fails without its fix.

### 1. Leave a map that was extracted from actually usable — `47ae24a`

`extract()` moves `m_values` out but never touches the buckets, so they keep indexing into the container that just left. The table then looks fine from the outside — `size()` is 0, `empty()` is true, `find()` returns `end()` because `do_find()` checks `empty()` first — and the first insert after that probes a stale bucket and dereferences it:

```
extracted 100, map: size=0 bucket_count=128
AddressSanitizer: SEGV on unknown address 0x000000000008
```

README §3.3.2 and the comment on the function both say "*this is emptied", and P0429's `extract()`, which that comment cites, leaves the container empty *and* usable. The existing test destroys the map right after extracting, which is why nothing caught it.

### 2. Refuse a max_load_factor open addressing cannot honour — `07c8b42`

`max_load_factor(2.0F)` was accepted and then hung. `m_max_bucket_capacity` is `bucket_count() * max_load_factor()`, so above 1 it exceeds the number of buckets, `is_full()` never fires, the table fills completely, and the next `place_and_shift_up()` walks the buckets forever looking for the empty one a full table does not have. `std::unordered_map` takes a load factor above 1 quite legitimately — it chains — so this is a reasonable thing for a caller to write.

Clamped to 1. Exactly 1 stays allowed and is safe, because `is_full()` is checked after the value has been appended; the new test runs a full 1.0 table through inserts, lookups and erases to keep it that way.

### 3. Say what the noexcept specifications meant to say — `770f6aa`

The move assignment and `swap()` were both written as `noexcept(noexcept(trait && trait))`. The inner `noexcept()` asks whether evaluating its operand can throw, and the operand is a bool expression, which never can — so both were `noexcept(true)` whatever the traits said, and the traits were dead code. A map whose hasher, comparator or container has a throwing move assignment promised not to throw, and would have called `std::terminate` on the way out:

```
                       before            after
move-assign noexcept:  throwing-hash=1   throwing-hash=0
swap noexcept:         throwing-hash=1   throwing-hash=0
```

The default map is unaffected — it was and remains `noexcept`, so `std::vector<map>` goes on moving its elements when it grows. Pinned with `static_assert`s in a new `test/unit/noexcept_contract.cpp`, since a specification like this is invisible at runtime until the day it isn't.

### 4. Exchange two maps without allocating three times — `1110d55`

`swap()` was `using std::swap; swap(other, *this)`, and there is no free `swap()` for `table`, so it resolved to the generic `std::swap`: a move construction and two move assignments. The move assignment hands the moved-from table a freshly allocated set of buckets so it stays usable — right for a move, pure waste in a swap. Measured with an allocation-counting allocator:

```
member swap of two maps: 3 allocations, 96 bytes   →   0 allocations, 0 bytes
```

Three chances to throw `std::bad_alloc` out of a function declared `noexcept`, on top of the cost. Swapping the eight members directly is what the standard containers do.

This commit also adds the free `swap()` standard containers provide: generic code written as `using std::swap; swap(a, b);` was landing on `std::swap` and paying the three moves. As a side effect, a map with a stateful, non-default-constructible allocator can now be swapped at all — the `std::swap` path needed the move constructor, which default constructs the bucket container's allocator.

## Testing

`meson test` passes with gcc C++17, clang C++23, and gcc `-Db_sanitize=address,undefined` with `halt_on_error=1`. Linters pass (`lint-version`, `lint-stdint-types-modules`, `lint-clang-tidy` at the pinned clang-tidy-18).

Nothing here touches `do_find`, `do_erase`, `do_try_emplace` or `place_and_shift_up`, and `bench_quick_overall_udm` run interleaved against `main` (clang, release, 3 paired runs) shows no consistent winner — 0.0856/0.0872/0.0876 baseline against 0.0880/0.0853/0.0873, mixed and inside the ±3% code-layout noise.

## Not included

Two things from the same reading pass, left out to keep this reviewable:

- `segmented_vector::iter_t` advertises `forward_iterator_tag` while implementing `--`, `+`, `-`, `+=`, `<` and iterator subtraction, so `std::distance` walks the container and `std::sort` over `values()` is ill-formed even though every operation it needs is present.
- `do_erase`'s callback runs after `erase_and_shift_down()`, so a throwing move constructor leaves a bucket removed and the value still in `m_values`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxhyeMXim7Pvb8SmYoEdBk)_