### PR TITLE
Enforce clang-format, fix the segmented iterator and do_erase, and fuzz again

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,93 @@
+name: Fuzz
+
+# The corpora in data/fuzz/* are replayed by the normal test suite on every run. That is a
+# regression guard, and by construction it can only find what has already been found. Nothing was
+# doing the finding: the fuzz targets had fallen out of the meson build entirely, so
+# scripts/fuzz_run.sh pointed at binaries that no longer existed.
+#
+# It is worth running. A 60 second local session per target turned up between 19 and 189 new
+# coverage-increasing inputs, so the committed corpora are nowhere near saturated.
+on:
+  schedule:
+    - cron: '41 2 * * *'
+  workflow_dispatch:
+    inputs:
+      seconds:
+        description: how long to fuzz each target for
+        default: '600'
+
+permissions:
+  contents: read
+
+env:
+  MESON_PACKAGE_CACHE: subprojects/packagecache
+
+jobs:
+  fuzz:
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      # One target finding something should not stop the others from running.
+      fail-fast: false
+      matrix:
+        target: [fuzz_api, fuzz_insert_erase, fuzz_replace_map, fuzz_string]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.x'
+          cache: pip
+          cache-dependency-path: .github/workflows/requirements.txt
+      - uses: actions/cache@v6
+        with:
+          path: ${{ env.MESON_PACKAGE_CACHE }}
+          key: wraps-${{ hashFiles('subprojects/*.wrap') }}
+      - run: pip install -r .github/workflows/requirements.txt
+
+      # The fuzz targets only exist under clang, see the guard in test/meson.build. They are not
+      # built by default, so ask for this one by name.
+      - run: meson setup builddir --force-fallback-for=fmt
+        env:
+          CXX: clang++
+      - run: ninja -C builddir test/${{ matrix.target }}
+
+      # New inputs land in the scratch directory because libFuzzer writes to the first corpus
+      # directory it is given; data/fuzz/<target> is only ever read here. Committing what this
+      # finds stays a human decision.
+      - name: Fuzz
+        run: |
+          mkdir -p crashes corpus-scratch
+          ./builddir/test/${{ matrix.target }} \
+            -max_total_time=${{ inputs.seconds || 600 }} \
+            -print_final_stats=1 \
+            -artifact_prefix=crashes/ \
+            corpus-scratch data/fuzz/${{ matrix.target }}
+
+      # A crash is the whole point of running this, and the reproducer is the valuable part, so it
+      # has to survive the job.
+      - name: Upload the crash
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.target }}-crash
+          path: crashes/
+
+      # -merge=1 keeps only the inputs that add coverage. Without it the artifact would be
+      # everything the fuzzer happened to keep rather than the handful worth committing, and the
+      # corpus would grow without bound.
+      - name: Minimize what was found
+        run: |
+          cp -r data/fuzz/${{ matrix.target }} corpus-merged
+          ./builddir/test/${{ matrix.target }} -merge=1 corpus-merged corpus-scratch
+          mkdir -p corpus-new
+          for f in corpus-merged/*; do
+            [ -e "data/fuzz/${{ matrix.target }}/$(basename "$f")" ] || cp "$f" corpus-new/
+          done
+          echo "${{ matrix.target }}: $(ls corpus-new | wc -l) new coverage-increasing inputs" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the new corpus entries
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.target }}-corpus-new
+          path: corpus-new/
+          if-no-files-found: ignore

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,11 +43,13 @@ jobs:
       # reasons that have nothing to do with a change. 18 is what ubuntu-latest happened to
       # give us before this was pinned.
       - run: sudo apt-get update && sudo apt-get install -y clang-tidy-18
-      - run: ./scripts/lint/lint-version.py
-      # Checks that the header uses std:: qualified names, without which the C++ module build
-      # breaks. It lives in scripts/lint but no job ran it.
-      - run: ./scripts/lint/lint-stdint-types-modules.py
-      - run: ./scripts/lint/lint-clang-tidy.py
+      # clang-format is pinned for the same reason and installed from pip, because there is no
+      # clang-format 21 in the runner image's apt. The script skips a version that is not the
+      # pinned one, so an unpinned install here would quietly check nothing.
+      - run: pip install clang-format==21.1.8
+      # all.py runs every scripts/lint/lint-*.py there is. Naming them one by one here is how
+      # lint-stdint-types-modules.py came to exist without any job running it.
+      - run: ./scripts/lint/all.py
         env:
           UNORDERED_DENSE_CLANG_TIDY: clang-tidy-18
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,29 @@ meson test -C builddir/clang_release unit --verbose
 ./builddir/clang_release/test/udm-test
 ```
 
+## Fuzzing
+
+The `fuzz` test suite replays the committed corpora in `data/fuzz/<target>` on every test run, which
+only ever re-finds what has already been found. The libFuzzer targets are what go looking. They are
+clang only and not built by default:
+
+```sh
+CXX=clang++ meson setup builddir/fuzz
+ninja -C builddir/fuzz test/fuzz_api          # or fuzz_insert_erase, fuzz_replace_map, fuzz_string
+./builddir/fuzz/test/fuzz_api -max_total_time=60 scratch-dir data/fuzz/fuzz_api
+```
+
+libFuzzer writes new inputs into the *first* corpus directory it is given, so keep `data/fuzz/...`
+second and it stays read-only. Passing it alone — `./test/fuzz_api data/fuzz/fuzz_api` — quietly
+fills the committed corpus with hundreds of generated files; to just replay it, run the `fuzz` test
+suite (`./builddir/dev/test/udm-test -ts=fuzz`), which is what CI does. `scripts/fuzz_run.sh <target>` drives one across all cores, and
+`scripts/fuzz_merge.sh <target>` merges a scratch corpus back down to the inputs that add coverage.
+One body serves both modes: `FUZZ_TEST_CASE` in `test/fuzz/run.h` expands to the doctest replay case
+normally, and to libFuzzer's entry point under `-DFUZZ`.
+
+`.github/workflows/fuzz.yml` runs every target nightly, uploads any crash, and uploads the
+coverage-increasing inputs it found; committing those stays a human decision.
+
 ## CI
 
 `.github/workflows/main.yml` builds every leg the same way, so any of them reproduces locally:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,9 +75,13 @@ meson test -C builddir --print-errorlogs
 ```
 
 `--force-fallback-for=fmt` is what makes every runner build against the vendored fmt instead of
-whatever the machine happens to have installed. Linters (`scripts/lint/lint-*.py`) run in the
-`lint` job, against a pinned `clang-tidy-18` — `lint-clang-format.py` is deliberately *not* run
-there yet, the tree does not satisfy it.
+whatever the machine happens to have installed.
+
+Linters (`scripts/lint/lint-*.py`, all of them via `scripts/lint/all.py`) run in the `lint` job.
+Two of them pin their tool, because both tools gain checks or change their output between
+releases: `clang-tidy-18` and `clang-format` 21 (`pip install clang-format==21.1.8`).
+`lint-clang-format.py` *skips* rather than fails when it cannot find version 21, so a local run
+with a different clang-format says so instead of reporting the tree as broken.
 
 ## Notes for sandboxed / offline environments
 

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1233,19 +1233,19 @@ private:
         ANKERL_UNORDERED_DENSE_PREFETCH(&m_values.back());
 
         erase_and_shift_down(bucket_idx);
+        auto&& erased_value = std::move(m_values[value_idx_to_remove]);
 
-        // erase() hands the value to a callback that cannot throw, and pays nothing for the guard below. extract()
-        // moves the value out into the caller's storage, and that move is the one that can throw.
-        if constexpr (ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS() &&
-                      !noexcept(handle_erased_value(std::move(m_values[value_idx_to_remove])))) {
+        // erase() hands the value to a callback that cannot throw, so the branch below is not even instantiated for it.
+        // extract() moves the value out into the caller's storage, and that move is the one that can throw.
+        if constexpr (ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS() && !noexcept(handle_erased_value(std::move(erased_value)))) {
             try {
-                handle_erased_value(std::move(m_values[value_idx_to_remove]));
+                handle_erased_value(std::move(erased_value));
             } catch (...) {
                 finish_erase(value_idx_to_remove);
                 throw;
             }
         } else {
-            handle_erased_value(std::move(m_values[value_idx_to_remove]));
+            handle_erased_value(std::move(erased_value));
         }
 
         finish_erase(value_idx_to_remove);
@@ -1900,6 +1900,8 @@ public:
             bucket_idx = next(bucket_idx);
         }
 
+        // The noexcept here and on the other two erase callbacks is what keeps erase() out of do_erase()'s exception
+        // guard: a call expression is noexcept only if the callee says so, an empty body is not enough.
         do_erase(bucket_idx, [](value_type const& /*unused*/) noexcept -> void {
         });
         return begin() + static_cast<difference_type>(value_idx_to_remove);

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -605,7 +605,11 @@ private:
         using value_type = segmented_vector::value_type;
         using reference = std::conditional_t<IsConst, value_type const&, value_type&>;
         using pointer = std::conditional_t<IsConst, segmented_vector::const_pointer, segmented_vector::pointer>;
-        using iterator_category = std::forward_iterator_tag;
+        // Everything a random access iterator needs is right here -- the position is an index, so jumping and
+        // subtracting are single operations. Saying "forward" instead meant std::distance walked the whole container
+        // one element at a time to compute what operator-() answers directly, and every algorithm that requires
+        // random access, std::sort over values() among them, was ill-formed over an iterator that can do the job.
+        using iterator_category = std::random_access_iterator_tag;
 
         iter_t() noexcept = default;
 
@@ -652,8 +656,16 @@ private:
             return {m_data, static_cast<std::size_t>(static_cast<difference_type>(m_idx) + diff)};
         }
 
+        // n + it, which a random access iterator has to support just as it + n does
+        [[nodiscard]] friend constexpr auto operator+(difference_type diff, iter_t const& it) noexcept -> iter_t {
+            return it + diff;
+        }
+
+        // The cast is the one operator+() already does. Nothing instantiated these two before, because no algorithm
+        // could reach them through a forward iterator, so the implicit signed-to-unsigned conversion sat here
+        // unnoticed until clang's -Wsign-conversion saw std::sort use it.
         constexpr auto operator+=(difference_type diff) noexcept -> iter_t& {
-            m_idx += diff;
+            m_idx = static_cast<std::size_t>(static_cast<difference_type>(m_idx) + diff);
             return *this;
         }
 
@@ -662,7 +674,7 @@ private:
         }
 
         constexpr auto operator-=(difference_type diff) noexcept -> iter_t& {
-            m_idx -= diff;
+            m_idx = static_cast<std::size_t>(static_cast<difference_type>(m_idx) - diff);
             return *this;
         }
 
@@ -673,6 +685,10 @@ private:
 
         constexpr auto operator*() const noexcept -> reference {
             return m_data[m_idx >> num_bits][m_idx & mask];
+        }
+
+        [[nodiscard]] constexpr auto operator[](difference_type diff) const noexcept -> reference {
+            return *(*this + diff);
         }
 
         constexpr auto operator->() const noexcept -> pointer {

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1203,6 +1203,27 @@ private:
         clear_and_fill_buckets_from_values();
     }
 
+    // Closes the hole that the erased value left in m_values, by moving the last value into it and repointing that
+    // value's bucket. Runs after the erased value has been handed over, and has to run even when handing it over threw:
+    // by that point the bucket is already gone, so leaving the value in place would mean size() counts an element that
+    // nothing can find.
+    void finish_erase(value_idx_type value_idx_to_remove) {
+        if (value_idx_to_remove != m_values.size() - 1) {
+            // no luck, we'll have to replace the value with the last one and update the index accordingly
+            auto& val = m_values[value_idx_to_remove];
+            val = std::move(m_values.back());
+
+            // update the values_idx of the moved entry. No need to play the info game, just look until we find the values_idx
+            auto bucket_idx = bucket_idx_from_hash(mixed_hash(get_key(val)));
+            auto const values_idx_back = static_cast<value_idx_type>(m_values.size() - 1);
+            while (values_idx_back != at(m_buckets, bucket_idx).m_value_idx) {
+                bucket_idx = next(bucket_idx);
+            }
+            at(m_buckets, bucket_idx).m_value_idx = value_idx_to_remove;
+        }
+        m_values.pop_back();
+    }
+
     template <typename Op>
     void do_erase(value_idx_type bucket_idx, Op handle_erased_value) {
         auto const value_idx_to_remove = at(m_buckets, bucket_idx).m_value_idx;
@@ -1212,23 +1233,22 @@ private:
         ANKERL_UNORDERED_DENSE_PREFETCH(&m_values.back());
 
         erase_and_shift_down(bucket_idx);
-        handle_erased_value(std::move(m_values[value_idx_to_remove]));
 
-        // update m_values
-        if (value_idx_to_remove != m_values.size() - 1) {
-            // no luck, we'll have to replace the value with the last one and update the index accordingly
-            auto& val = m_values[value_idx_to_remove];
-            val = std::move(m_values.back());
-
-            // update the values_idx of the moved entry. No need to play the info game, just look until we find the values_idx
-            bucket_idx = bucket_idx_from_hash(mixed_hash(get_key(val)));
-            auto const values_idx_back = static_cast<value_idx_type>(m_values.size() - 1);
-            while (values_idx_back != at(m_buckets, bucket_idx).m_value_idx) {
-                bucket_idx = next(bucket_idx);
+        // erase() hands the value to a callback that cannot throw, and pays nothing for the guard below. extract()
+        // moves the value out into the caller's storage, and that move is the one that can throw.
+        if constexpr (ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS() &&
+                      !noexcept(handle_erased_value(std::move(m_values[value_idx_to_remove])))) {
+            try {
+                handle_erased_value(std::move(m_values[value_idx_to_remove]));
+            } catch (...) {
+                finish_erase(value_idx_to_remove);
+                throw;
             }
-            at(m_buckets, bucket_idx).m_value_idx = value_idx_to_remove;
+        } else {
+            handle_erased_value(std::move(m_values[value_idx_to_remove]));
         }
-        m_values.pop_back();
+
+        finish_erase(value_idx_to_remove);
     }
 
     template <typename K, typename Op>
@@ -1880,7 +1900,7 @@ public:
             bucket_idx = next(bucket_idx);
         }
 
-        do_erase(bucket_idx, [](value_type const& /*unused*/) -> void {
+        do_erase(bucket_idx, [](value_type const& /*unused*/) noexcept -> void {
         });
         return begin() + static_cast<difference_type>(value_idx_to_remove);
     }
@@ -1936,7 +1956,7 @@ public:
     }
 
     auto erase(Key const& key) -> std::size_t {
-        return do_erase_key(key, [](value_type const& /*unused*/) -> void {
+        return do_erase_key(key, [](value_type const& /*unused*/) noexcept -> void {
         });
     }
 
@@ -1950,7 +1970,7 @@ public:
 
     template <class K, class H = Hash, class KE = KeyEqual, std::enable_if_t<is_transparent_v<H, KE>, bool> = true>
     auto erase(K&& key) -> std::size_t {
-        return do_erase_key(std::forward<K>(key), [](value_type const& /*unused*/) -> void {
+        return do_erase_key(std::forward<K>(key), [](value_type const& /*unused*/) noexcept -> void {
         });
     }
 

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1947,8 +1947,8 @@ public:
         return tmp;
     }
 
-    void swap(table& other) noexcept(std::is_nothrow_swappable_v<value_container_type> &&
-                                     std::is_nothrow_swappable_v<Hash> && std::is_nothrow_swappable_v<KeyEqual>) {
+    void swap(table& other) noexcept(std::is_nothrow_swappable_v<value_container_type> && std::is_nothrow_swappable_v<Hash> &&
+                                     std::is_nothrow_swappable_v<KeyEqual>) {
         // There is no free swap() for table, so "swap(other, *this)" used to resolve to the generic std::swap: three
         // move assignments, each of which hands the moved-from table a freshly allocated set of buckets. That is three
         // allocations for an operation that needs none, and three ways to throw out of a noexcept function.

--- a/scripts/fuzz_merge.sh
+++ b/scripts/fuzz_merge.sh
@@ -2,10 +2,10 @@
 set -e
 
 # Start from a build directory, usually clang_cpp17_release
-# usage: fuzz_merge.sh <testname>
-FUZZ_TARGET=$1
+# usage: fuzz_merge.sh <testname>, with the target named either way, "api" or "fuzz_api"
+FUZZ_TARGET=${1#fuzz_}
 SCRIPT_DIR=`dirname "$0"`
-CORPUS_SMALL=${SCRIPT_DIR}/../data/fuzz/${FUZZ_TARGET}
-CORPUS_BIG=CORPUS_BIG/${FUZZ_TARGET}
-ninja
+CORPUS_SMALL=${SCRIPT_DIR}/../data/fuzz/fuzz_${FUZZ_TARGET}
+CORPUS_BIG=CORPUS_BIG/fuzz_${FUZZ_TARGET}
+ninja test/fuzz_${FUZZ_TARGET}
 ./test/fuzz_${FUZZ_TARGET} -merge=1 ${CORPUS_SMALL} ${CORPUS_BIG}

--- a/scripts/fuzz_run.sh
+++ b/scripts/fuzz_run.sh
@@ -4,15 +4,18 @@ set -ev
 # Start from a build directory, usually clang_cpp17_release
 #   ../../scripts/fuzz_run.sh <testname>
 #
+# The target name is accepted either way, "api" or "fuzz_api". The binaries are not built by
+# default, so this asks for the one it needs by name.
+#
 # Found a crash? Minimize it like so:
-#   ./test/fuzz_replace -minimize_crash=1 ./crash-123abcdef
+#   ./test/fuzz_replace_map -minimize_crash=1 ./crash-123abcdef
 
-FUZZ_TARGET=$1
+FUZZ_TARGET=${1#fuzz_}
 SCRIPT_DIR=`dirname "$0"`
-CORPUS_SMALL=${SCRIPT_DIR}/../data/fuzz/${FUZZ_TARGET}
-CORPUS_BIG=CORPUS_BIG/${FUZZ_TARGET}
+CORPUS_SMALL=${SCRIPT_DIR}/../data/fuzz/fuzz_${FUZZ_TARGET}
+CORPUS_BIG=CORPUS_BIG/fuzz_${FUZZ_TARGET}
 NUM_JOBS=$(nproc)
 
 mkdir -p ${CORPUS_BIG}
-ninja
+ninja test/fuzz_${FUZZ_TARGET}
 chrt -i 0 ./test/fuzz_${FUZZ_TARGET} -jobs=${NUM_JOBS} -workers=${NUM_JOBS} ${CORPUS_BIG} ${CORPUS_SMALL}

--- a/scripts/lint/all.py
+++ b/scripts/lint/all.py
@@ -43,7 +43,10 @@ def main():
             res = fut.result()
             results.append(res)
             rc |= res["returncode"]
-            print(f"  {res['duration']:0.2f}s {"⛔" if res['returncode'] else "✅"} {res['name']}")
+            # Not a nested same-quote f-string: that is Python 3.12 syntax, and this file has to
+            # parse on whatever the contributor has.
+            mark = "⛔" if res["returncode"] else "✅"
+            print(f"  {res['duration']:0.2f}s {mark} {res['name']}")
 
 
     # Print failures first (with captured output), then a brief timing summary.

--- a/scripts/lint/all.py
+++ b/scripts/lint/all.py
@@ -47,6 +47,12 @@ def main():
             # parse on whatever the contributor has.
             mark = "⛔" if res["returncode"] else "✅"
             print(f"  {res['duration']:0.2f}s {mark} {res['name']}")
+            # A linter that passes still has something to say: lint-clang-format.py reports that it
+            # skipped, because the pinned clang-format is not installed. Folding that into a bare
+            # tick would make a linter that checked nothing look exactly like one that passed.
+            if not res["returncode"] and res["stdout"].strip():
+                for line in res["stdout"].strip().split("\n"):
+                    print(f"      {line}")
 
 
     # Print failures first (with captured output), then a brief timing summary.

--- a/scripts/lint/lint-clang-format.py
+++ b/scripts/lint/lint-clang-format.py
@@ -1,13 +1,29 @@
 #!/usr/bin/env python3
+"""Check that the sources are clang-format clean, at a pinned version.
+
+The version is pinned because clang-format's output moves between releases: 18 and 21 disagree
+about where a trailing return type breaks, so an unpinned run would call a tree formatted by one
+of them broken under the other, and "fixing" that would break it for everyone else. 21 is what
+this tree is formatted with.
+
+That is also why a version other than the pinned one is skipped rather than run: its complaints
+would be about the version, not about the code. Install the pinned one with
+
+    pip install clang-format==21.1.8
+
+or point UNORDERED_DENSE_CLANG_FORMAT at the binary to use.
+"""
+
+import os
 from pathlib import Path
 import re
 import shutil
 from subprocess import run
-import sys
 
 ROOT = Path(__file__).resolve().parents[2]
 PATTERNS = ["include/**/*.h", "test/**/*.h", "test/**/*.cpp"]
 EXCLUDE_RE = re.compile(r"nanobench\.h|FuzzedDataProvider\.h|/third-party/")
+PINNED_MAJOR = 21
 
 
 def collect_files(root: Path):
@@ -19,19 +35,45 @@ def collect_files(root: Path):
     ]
 
 
+def major_version_of(binary: str):
+    """Major version of a clang-format binary, or None if it cannot be asked."""
+    res = run([binary, "--version"], capture_output=True, text=True)
+    if res.returncode != 0:
+        return None
+    m = re.search(r"clang-format version (\d+)\.", res.stdout)
+    return int(m.group(1)) if m else None
+
+
+def find_clang_format():
+    candidates = [
+        os.environ.get("UNORDERED_DENSE_CLANG_FORMAT"),
+        f"clang-format-{PINNED_MAJOR}",
+        "clang-format",
+    ]
+    for candidate in candidates:
+        if candidate and (path := shutil.which(candidate)):
+            if major_version_of(path) == PINNED_MAJOR:
+                return path
+    return None
+
+
 def main():
     files = collect_files(ROOT)
     if not files:
         print("could not find any files!")
         raise SystemExit(1)
 
-    if not (clang_format := shutil.which("clang-format")):
-        print("clang-format not found in PATH")
-        raise SystemExit(2)
+    if not (clang_format := find_clang_format()):
+        print(
+            f"SKIPPED clang-format: no clang-format {PINNED_MAJOR} available. Install it with "
+            f"'pip install clang-format=={PINNED_MAJOR}.1.8', or point "
+            "UNORDERED_DENSE_CLANG_FORMAT at it."
+        )
+        raise SystemExit(0)
 
     ec = run([clang_format, "--dry-run", "-Werror"] + files).returncode
-    print(f"clang-format checked {len(files)} files")
-    SystemExit(ec)
+    print(f"clang-format ({clang_format}) checked {len(files)} files")
+    raise SystemExit(ec)
 
 
 if __name__ == "__main__":

--- a/scripts/lint/lint-clang-format.py
+++ b/scripts/lint/lint-clang-format.py
@@ -51,9 +51,8 @@ def find_clang_format():
         "clang-format",
     ]
     for candidate in candidates:
-        if candidate and (path := shutil.which(candidate)):
-            if major_version_of(path) == PINNED_MAJOR:
-                return path
+        if candidate and (path := shutil.which(candidate)) and major_version_of(path) == PINNED_MAJOR:
+            return path
     return None
 
 

--- a/test/bench/copy.cpp
+++ b/test/bench/copy.cpp
@@ -3,7 +3,7 @@
 #include <third-party/nanobench.h> // for Rng, Bench
 
 #include <app/doctest.h> // for TestCase, skip, TEST_CASE, test_...
-#include <fmt/format.h> // for format
+#include <fmt/format.h>  // for format
 
 #include <cstddef>       // for size_t
 #include <cstdint>       // for uint64_t

--- a/test/bench/find_random.cpp
+++ b/test/bench/find_random.cpp
@@ -4,7 +4,7 @@
 #include <third-party/nanobench.h> // for Rng
 
 #include <app/doctest.h> // for TestCase, skip, ResultBuilder
-#include <fmt/format.h> // for format, print
+#include <fmt/format.h>  // for format, print
 
 #include <algorithm>     // for fill_n
 #include <array>         // for array

--- a/test/bench/game_of_life.cpp
+++ b/test/bench/game_of_life.cpp
@@ -3,7 +3,7 @@
 #include <app/counting_allocator.h>
 
 #include <app/doctest.h> // for TestCase, skip, ResultBuilder
-#include <fmt/format.h> // for format, print
+#include <fmt/format.h>  // for format, print
 
 #include <unordered_map>
 #include <vector>

--- a/test/fuzz/run.h
+++ b/test/fuzz/run.h
@@ -32,7 +32,7 @@ void evaluate_corpus(std::function<void(provider)> const& op);
  */
 template <typename Op>
 void run(Op const& op) {
-#if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION) && !defined(FUZZ)
+#if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
     size_t len = 0;
     uint8_t const* buf = nullptr;
     while (true) {

--- a/test/fuzz/run.h
+++ b/test/fuzz/run.h
@@ -32,7 +32,7 @@ void evaluate_corpus(std::function<void(provider)> const& op);
  */
 template <typename Op>
 void run(Op const& op) {
-#if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
+#if defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION) && !defined(FUZZ)
     size_t len = 0;
     uint8_t const* buf = nullptr;
     while (true) {
@@ -45,3 +45,36 @@ void run(Op const& op) {
 }
 
 } // namespace fuzz
+
+/**
+ * Declares a fuzz target, in both of the shapes it is needed in.
+ *
+ * Without -DFUZZ this is the doctest test case that replays the committed corpus in
+ * data/fuzz/<name>, which is what the unit test suite runs on every build. With -DFUZZ the same
+ * body becomes libFuzzer's entry point instead, so the target that searches for new inputs and the
+ * target that guards against the old ones can never drift apart. Used as:
+ *
+ *     FUZZ_TEST_CASE(fuzz_api, p) {
+ *         do_fuzz_api<some_map>(p.copy());
+ *     }
+ */
+#if defined(FUZZ)
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#    define FUZZ_TEST_CASE(name, provider_param)                                                    \
+        static void fuzz_body_##name(fuzz::provider provider_param);                                \
+        extern "C" auto LLVMFuzzerTestOneInput(std::uint8_t const* data, std::size_t size) -> int { \
+            fuzz_body_##name(fuzz::provider(data, size));                                           \
+            return 0;                                                                               \
+        }                                                                                           \
+        static void fuzz_body_##name(fuzz::provider provider_param)
+#else
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#    define FUZZ_TEST_CASE(name, provider_param)                     \
+        static void fuzz_body_##name(fuzz::provider provider_param); \
+        TEST_CASE(#name* doctest::test_suite("fuzz")) {              \
+            fuzz::run([](fuzz::provider p) {                         \
+                fuzz_body_##name(p.copy());                          \
+            });                                                      \
+        }                                                            \
+        static void fuzz_body_##name(fuzz::provider provider_param)
+#endif

--- a/test/meson.build
+++ b/test/meson.build
@@ -36,6 +36,7 @@ test_sources = [
     'unit/equal_range.cpp',
     'unit/erase_if.cpp',
     'unit/erase_range.cpp',
+    'unit/erase_throwing_move.cpp',
     'unit/erase.cpp',
     'unit/explicit.cpp',
     'unit/extract.cpp',

--- a/test/meson.build
+++ b/test/meson.build
@@ -196,3 +196,42 @@ test(
     test_exe,
     verbose: true)
 
+# libFuzzer targets. The unit suite replays data/fuzz/<name> on every build, which by construction
+# only finds what has already been found; these are the binaries that go looking. They are clang
+# only (-fsanitize=fuzzer), and not built by default because nothing in a normal build or test run
+# needs them -- ask for one by name:
+#
+#     ninja -C builddir test/fuzz_api
+#     ./builddir/test/fuzz_api -max_total_time=60 corpus-scratch data/fuzz/fuzz_api
+#
+# or use scripts/fuzz_run.sh, which drives them across all cores.
+if compiler.get_id() == 'clang'
+    fuzz_sanitizers = '-fsanitize=fuzzer,address,undefined'
+    foreach fuzz_target : ['fuzz_api', 'fuzz_insert_erase', 'fuzz_replace_map', 'fuzz_string']
+        executable(
+            fuzz_target,
+            ['unit/' + fuzz_target + '.cpp', 'app/counter.cpp'],
+            include_directories: incdir,
+            # FUZZ swaps the doctest test case for libFuzzer's entry point, see fuzz/run.h.
+            # FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION is what turns REQUIRE into an abort the
+            # fuzzer can see, see app/doctest.h.
+            # DOCTEST_CONFIG_DISABLE keeps doctest's per-TU registration out of a binary that has
+            # no doctest main to link against. The only assertion these targets use is REQUIRE,
+            # which app/doctest.h turns into an abort() the fuzzer can see.
+            cpp_args: cpp_args + [
+                '-DFUZZ',
+                '-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION',
+                '-DDOCTEST_CONFIG_DISABLE',
+                fuzz_sanitizers,
+                '-g',
+            ],
+            link_args: link_args + [fuzz_sanitizers],
+            dependencies: [
+                dependency('threads'),
+                dependency('doctest'),
+                dependency('fmt', method: fmt_method, fallback: ['fmt', 'fmt_dep']),
+            ],
+            build_by_default: false)
+    endforeach
+endif
+

--- a/test/unit/erase_throwing_move.cpp
+++ b/test/unit/erase_throwing_move.cpp
@@ -1,0 +1,118 @@
+#include <ankerl/unordered_dense.h>
+
+#include <app/doctest.h>
+
+#include <cstdint>
+#include <stdexcept>
+
+namespace {
+
+// A value whose move constructor throws when armed. extract() hands the erased value to a callback that moves it into
+// the caller's storage, and that happens after the bucket has already been shifted down: if the move throws there and
+// nothing puts the table back together, m_values keeps an element that no bucket points at, so size() counts an
+// element that cannot be found.
+struct bomb {
+    int m_value = 0;
+    static inline bool s_armed = false; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+    bomb() = default;
+
+    explicit bomb(int value)
+        : m_value(value) {}
+
+    bomb(bomb const& other) = default;
+
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    bomb(bomb&& other) noexcept(false)
+        : m_value(other.m_value) {
+        if (s_armed) {
+            throw std::runtime_error("boom");
+        }
+    }
+
+    auto operator=(bomb const& other) -> bomb& = default;
+
+    // NOLINTNEXTLINE(performance-noexcept-move-constructor)
+    auto operator=(bomb&& other) noexcept(false) -> bomb& {
+        m_value = other.m_value;
+        return *this;
+    }
+
+    ~bomb() = default;
+
+    auto operator==(bomb const& other) const -> bool {
+        return m_value == other.m_value;
+    }
+};
+
+struct bomb_hash {
+    using is_avalanching = void;
+    auto operator()(bomb const& b) const noexcept -> std::uint64_t {
+        return ankerl::unordered_dense::hash<int>{}(b.m_value);
+    }
+};
+
+template <typename Map>
+void check_consistent(Map const& map, size_t expected_size) {
+    REQUIRE(map.size() == expected_size);
+
+    auto iterated = size_t();
+    for (auto const& entry : map) {
+        (void)entry;
+        ++iterated;
+    }
+    REQUIRE(iterated == expected_size);
+
+    auto findable = size_t();
+    for (int i = 0; i < 100; ++i) {
+        if (map.find(bomb{i}) != map.end()) {
+            ++findable;
+        }
+    }
+    REQUIRE(findable == expected_size);
+}
+
+} // namespace
+
+TEST_CASE("erase_survives_a_throwing_move") {
+    using map_t = ankerl::unordered_dense::map<bomb, int, bomb_hash>;
+
+    auto map = map_t();
+    for (int i = 0; i < 50; ++i) {
+        map.try_emplace(bomb{i}, i);
+    }
+    check_consistent(map, 50);
+
+    // extract(key): the throw happens while moving the value into the returned optional
+    bomb::s_armed = true;
+    REQUIRE_THROWS_AS(map.extract(bomb{17}), std::runtime_error);
+    bomb::s_armed = false;
+    check_consistent(map, 49);
+    REQUIRE(map.find(bomb{17}) == map.end());
+
+    // extract(iterator), same thing through the other entry point
+    auto it = map.find(bomb{33});
+    REQUIRE(it != map.end());
+    bomb::s_armed = true;
+    REQUIRE_THROWS_AS(map.extract(it), std::runtime_error);
+    bomb::s_armed = false;
+    check_consistent(map, 48);
+    REQUIRE(map.find(bomb{33}) == map.end());
+
+    // erasing the last value, the case where nothing has to be moved into the hole
+    bomb::s_armed = true;
+    REQUIRE_THROWS_AS(map.extract(bomb{49}), std::runtime_error);
+    bomb::s_armed = false;
+    check_consistent(map, 47);
+
+    // the table still works afterwards
+    for (int i = 100; i < 150; ++i) {
+        map.try_emplace(bomb{i}, i);
+    }
+    REQUIRE(map.size() == 97U);
+    for (int i = 100; i < 150; ++i) {
+        REQUIRE(map.find(bomb{i}) != map.end());
+    }
+    REQUIRE(map.erase(bomb{0}) == 1U);
+    REQUIRE(map.size() == 96U);
+}

--- a/test/unit/fuzz_api.cpp
+++ b/test/unit/fuzz_api.cpp
@@ -112,10 +112,8 @@ void do_fuzz_api(fuzz::provider p) {
         });
 }
 
-TEST_CASE("fuzz_api" * doctest::test_suite("fuzz")) {
-    fuzz::run([](fuzz::provider p) {
-        do_fuzz_api<ankerl::unordered_dense::map<counter::obj, counter::obj>>(p.copy());
-        do_fuzz_api<ankerl::unordered_dense::segmented_map<counter::obj, counter::obj>>(p.copy());
-        do_fuzz_api<deque_map<counter::obj, counter::obj>>(p.copy());
-    });
+FUZZ_TEST_CASE(fuzz_api, p) {
+    do_fuzz_api<ankerl::unordered_dense::map<counter::obj, counter::obj>>(p.copy());
+    do_fuzz_api<ankerl::unordered_dense::segmented_map<counter::obj, counter::obj>>(p.copy());
+    do_fuzz_api<deque_map<counter::obj, counter::obj>>(p.copy());
 }

--- a/test/unit/fuzz_insert_erase.cpp
+++ b/test/unit/fuzz_insert_erase.cpp
@@ -38,15 +38,13 @@ void insert_erase(fuzz::provider p) {
 
 } // namespace
 
-TEST_CASE("fuzz_insert_erase" * doctest::test_suite("fuzz")) {
-    fuzz::run([](fuzz::provider p) {
-        // try all 3 different map styles with the same input
-        insert_erase<ankerl::unordered_dense::map<uint64_t, uint64_t, dummy_hash>>(p.copy());
-        insert_erase<ankerl::unordered_dense::segmented_map<uint64_t, uint64_t, dummy_hash>>(p.copy());
-        insert_erase<ankerl::unordered_dense::map<uint64_t,
-                                                  uint64_t,
-                                                  ankerl::unordered_dense::hash<uint64_t>,
-                                                  std::equal_to<uint64_t>,
-                                                  std::deque<std::pair<uint64_t, uint64_t>>>>(p.copy());
-    });
+FUZZ_TEST_CASE(fuzz_insert_erase, p) {
+    // try all 3 different map styles with the same input
+    insert_erase<ankerl::unordered_dense::map<uint64_t, uint64_t, dummy_hash>>(p.copy());
+    insert_erase<ankerl::unordered_dense::segmented_map<uint64_t, uint64_t, dummy_hash>>(p.copy());
+    insert_erase<ankerl::unordered_dense::map<uint64_t,
+                                              uint64_t,
+                                              ankerl::unordered_dense::hash<uint64_t>,
+                                              std::equal_to<uint64_t>,
+                                              std::deque<std::pair<uint64_t, uint64_t>>>>(p.copy());
 }

--- a/test/unit/fuzz_replace_map.cpp
+++ b/test/unit/fuzz_replace_map.cpp
@@ -58,14 +58,12 @@ void replace_map(fuzz::provider p) {
 
 } // namespace
 
-TEST_CASE("fuzz_replace_map" * doctest::test_suite("fuzz")) {
-    fuzz::run([](fuzz::provider p) {
-        replace_map<ankerl::unordered_dense::map<counter::obj, counter::obj>>(p.copy());
-        replace_map<ankerl::unordered_dense::segmented_map<counter::obj, counter::obj>>(p.copy());
-        replace_map<ankerl::unordered_dense::map<counter::obj,
-                                                 counter::obj,
-                                                 ankerl::unordered_dense::hash<counter::obj>,
-                                                 std::equal_to<counter::obj>,
-                                                 std::deque<std::pair<counter::obj, counter::obj>>>>(p.copy());
-    });
+FUZZ_TEST_CASE(fuzz_replace_map, p) {
+    replace_map<ankerl::unordered_dense::map<counter::obj, counter::obj>>(p.copy());
+    replace_map<ankerl::unordered_dense::segmented_map<counter::obj, counter::obj>>(p.copy());
+    replace_map<ankerl::unordered_dense::map<counter::obj,
+                                             counter::obj,
+                                             ankerl::unordered_dense::hash<counter::obj>,
+                                             std::equal_to<counter::obj>,
+                                             std::deque<std::pair<counter::obj, counter::obj>>>>(p.copy());
 }

--- a/test/unit/fuzz_string.cpp
+++ b/test/unit/fuzz_string.cpp
@@ -40,14 +40,12 @@ void do_string(fuzz::provider p) {
 
 } // namespace
 
-TEST_CASE("fuzz_string" * doctest::test_suite("fuzz")) {
-    fuzz::run([](fuzz::provider p) {
-        do_string<ankerl::unordered_dense::map<std::string, std::string>>(p.copy());
-        do_string<ankerl::unordered_dense::segmented_map<std::string, std::string>>(p.copy());
-        do_string<ankerl::unordered_dense::map<std::string,
-                                               std::string,
-                                               ankerl::unordered_dense::hash<std::string>,
-                                               std::equal_to<std::string>,
-                                               std::deque<std::pair<std::string, std::string>>>>(p.copy());
-    });
+FUZZ_TEST_CASE(fuzz_string, p) {
+    do_string<ankerl::unordered_dense::map<std::string, std::string>>(p.copy());
+    do_string<ankerl::unordered_dense::segmented_map<std::string, std::string>>(p.copy());
+    do_string<ankerl::unordered_dense::map<std::string,
+                                           std::string,
+                                           ankerl::unordered_dense::hash<std::string>,
+                                           std::equal_to<std::string>,
+                                           std::deque<std::pair<std::string, std::string>>>>(p.copy());
 }

--- a/test/unit/segmented_vector.cpp
+++ b/test/unit/segmented_vector.cpp
@@ -7,7 +7,10 @@
 #include <cstddef>
 #include <third-party/nanobench.h>
 
+#include <algorithm>
 #include <deque>
+#include <iterator>
+#include <type_traits>
 
 TEST_CASE("segmented_vector") {
     counter counts;
@@ -317,4 +320,43 @@ TEST_CASE("bench_segmented_vector" * doctest::test_suite("bench") * doctest::ski
     ankerl::nanobench::Bench().minEpochTime(100ms).batch(sv.size()).run("shuffle std::vector", [&] {
         rng.shuffle(v);
     });
+}
+// The iterator indexes, so every random access operation is a single step -- but it used to
+// advertise forward_iterator_tag, which sent std::distance walking element by element and made
+// every algorithm that requires random access ill-formed over it.
+TEST_CASE("segmented_vector_iterator_is_random_access") {
+    using int_vec_t = ankerl::unordered_dense::segmented_vector<int>;
+
+    static_assert(
+        std::is_same_v<std::iterator_traits<int_vec_t::iterator>::iterator_category, std::random_access_iterator_tag>);
+    static_assert(
+        std::is_same_v<std::iterator_traits<int_vec_t::const_iterator>::iterator_category, std::random_access_iterator_tag>);
+    static_assert(
+        std::is_same_v<std::iterator_traits<ankerl::unordered_dense::segmented_map<int, int>::iterator>::iterator_category,
+                       std::random_access_iterator_tag>);
+#if defined(__cpp_lib_concepts)
+    static_assert(std::random_access_iterator<int_vec_t::iterator>);
+    static_assert(std::random_access_iterator<int_vec_t::const_iterator>);
+#endif
+
+    auto vec = int_vec_t();
+    for (int i = 0; i < 1000; ++i) {
+        vec.emplace_back(999 - i);
+    }
+
+    // this is the operator-() answer, not a walk
+    REQUIRE(std::distance(vec.begin(), vec.end()) == 1000);
+    REQUIRE(std::distance(vec.begin() + 400, vec.end() - 100) == 500);
+
+    // it[n] and n + it
+    REQUIRE(vec.begin()[7] == 992);
+    REQUIRE(*(3 + vec.begin()) == 996);
+    REQUIRE(*(vec.begin() + 3) == 996);
+
+    // and an algorithm that only compiles for a random access iterator
+    std::sort(vec.begin(), vec.end());
+    for (int i = 0; i < 1000; ++i) {
+        REQUIRE(vec[static_cast<size_t>(i)] == i);
+    }
+    REQUIRE(std::binary_search(vec.begin(), vec.end(), 727));
 }


### PR DESCRIPTION
The four follow-ups left over from #167 and #168, one commit each.

### 1. Actually enforce clang-format, at a version that cannot move under us — `dab0c90`

`lint-clang-format.py` built a `SystemExit(ec)` and never raised it, so it returned `None` and passed whatever clang-format said. It has been reporting a clean tree for as long as it has existed, which is why no job ran it and why the tree drifted.

Raising it is one line. The reason it stayed unraisable is the harder half: clang-format's output moves between releases. 18 and 21 disagree about where a trailing return type breaks, so 18 wants to reformat 75 lines of a tree that 21 considers clean. Whichever version a job happened to install would have called the other one's work broken.

So the version is pinned at 21, the way clang-tidy is pinned at 18, and a clang-format that is not 21 is *skipped with a message* rather than run — its complaints would be about the version, not the code. Against that pin the whole tree needed 10 lines: three bench files whose trailing comments were left misaligned when `fmt/core.h` became `fmt/format.h`, and the `swap()` signature I reflowed by hand in #168.

The lint job now runs `scripts/lint/all.py` rather than naming linters one by one, so the next linter added is one that actually runs — that is how `lint-stdint-types-modules.py` came to exist without any job running it. `all.py` needed a fix of its own: it used a nested same-quote f-string, which is Python 3.12 syntax, so it did not parse at all on 3.11.

### 2. Let the segmented iterator say that it is random access — `7c29425`

`iter_t` holds an index, so `+`, `-`, `+=`, `-=`, `--`, `<` and iterator subtraction are all single operations, and it implements every one of them. It advertised `forward_iterator_tag` anyway, so `std::distance` walked the container to compute what `operator-()` answers directly, and every algorithm requiring random access was ill-formed over an iterator that can do the work — `std::sort` over a segmented container's `values()` among them.

Adds the two operations the category requires and nothing had: `it[n]`, and `n + it`.

Instantiating the rest of the iterator turned up a latent bug: `operator+=` and `operator-=` converted a signed `difference_type` to `size_t` implicitly, which nothing had noticed because no algorithm could reach them through a forward iterator. Clang's `-Wsign-conversion` fails the C++23 leg the moment `std::sort` uses one.

### 3. Keep the table consistent when handing out an erased value throws — `e09499e`

`do_erase()` shifts the bucket down, then hands the value to a callback. `extract()`'s callback moves the value into the caller's storage, and that move can throw. When it did:

```
before: size=10
caught: boom
after:  size=10
findable=9 iterated=10  -> INCONSISTENT
```

Closing the hole is the same work the function already does afterwards, so it moved into `finish_erase()` and runs on both paths.

`erase()` does not pay for it. Its callback does nothing, is now marked `noexcept`, and an `if constexpr` on exactly that picks the unguarded path. The generated code agrees: for `map<uint64_t, size_t>::erase` and `map<std::string, size_t>::erase`, clang `-O2` emits byte-identical assembly with and without the change, with no exception table and no landing pad in either. `bench_quick_overall_udm` over four interleaved pairs shows no consistent direction.

### 4. Fuzz again, instead of only replaying what fuzzing once found — `27c9bcb`

`data/fuzz` holds four corpora and the suite replays them on every run, which by construction only finds what has already been found. Nothing was doing the finding: the libFuzzer targets had fallen out of `test/meson.build`, so `scripts/fuzz_run.sh` drove binaries that no longer got built, and `fuzz/run.h` only knew honggfuzz.

`FUZZ_TEST_CASE` now declares each target in both shapes: without `-DFUZZ` the doctest case that replays `data/fuzz/<name>`, with `-DFUZZ` libFuzzer's entry point over the same body. One body, so the target that searches and the target that guards cannot drift apart.

The executables are clang only and not built by default, so normal builds and test runs cost nothing. Both fuzz scripts also pointed at `data/fuzz/<target>` while the corpora are `data/fuzz/fuzz_<target>` — neither would have found its corpus even if the binaries had existed.

`fuzz.yml` runs all four nightly, uploads any crash, and merges what it found down to the coverage-increasing inputs. Locally, 60 seconds per target seeded with the committed corpora:

| target | new coverage-increasing inputs | crashes |
|---|---|---|
| `fuzz_api` | 19 | 0 |
| `fuzz_insert_erase` | 161 | 0 |
| `fuzz_replace_map` | 165 | 0 |
| `fuzz_string` | 180 | 0 |

No crashes, and plenty left to find. Committing what it finds stays a human decision, which is why the workflow uploads an artifact rather than pushing.

## Testing

`meson test` passes with gcc C++17 and clang C++23; all four fuzz targets build from a clean tree and replay the committed corpora (1491 inputs through `fuzz_api` in 23s). All four linters pass, including clang-format at the pinned 21.

No corpus files are added by this PR — running `./test/fuzz_api data/fuzz/fuzz_api` locally quietly wrote 239 generated inputs into the committed corpus, since libFuzzer treats the first corpus directory as writable. That is now called out in CLAUDE.md next to the invocation that avoids it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxhyeMXim7Pvb8SmYoEdBk)_