### PR TITLE
Halve CI wall clock by fixing the MinGW legs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -301,16 +301,26 @@ jobs:
     defaults:
       run:
         shell: msys2 {0}
+    env:
+      # Somewhere both halves of this job can reach: actions/cache runs as a Windows process and
+      # ccache is a native mingw binary, so the one path has to suit both.
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: 500M
     steps:
       - uses: actions/checkout@v7
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.msystem }}
-          update: true
+          # Not update: true. That is a full pacman -Syuu on top of the runner image, and it was
+          # the single most expensive thing in this job: 63s of an 82s setup step, every run, to
+          # upgrade packages this build does not use. The install list below is what it needs and
+          # it is pinned to nothing, so it still gets current versions of those.
+          update: false
           cache: true
           install: >-
             ca-certificates
             ${{ matrix.prefix }}-ca-certificates
+            ${{ matrix.prefix }}-ccache
             ${{ matrix.prefix }}-gcc
             ${{ matrix.prefix }}-meson
             ${{ matrix.prefix }}-ninja
@@ -320,9 +330,27 @@ jobs:
         with:
           path: ${{ env.MESON_PACKAGE_CACHE }}
           key: wraps-${{ hashFiles('subprojects/*.wrap') }}
-      - run: g++ --version
+
+      # The build matrix has had a compiler cache since it was rewritten; MinGW was the one job
+      # left without one, and compiling is most of what it does -- 107s of a 110s step, against a
+      # test that runs in two. hendrikmuhs/ccache-action is what the other jobs use, but it
+      # installs a Windows-native ccache that the msys2 shell does not see, so this wires up the
+      # msys2 one by hand. The key is per arch and per standard because the objects are not
+      # interchangeable between them; run_id makes every run save a fresh entry and the prefix
+      # restore-key picks up the most recent one.
+      - uses: actions/cache@v6
+        with:
+          path: .ccache
+          key: ccache-mingw-${{ matrix.sys }}-cpp${{ matrix.cxx_standard }}-${{ github.run_id }}
+          restore-keys: ccache-mingw-${{ matrix.sys }}-cpp${{ matrix.cxx_standard }}-
+      - run: g++ --version && ccache --version && ccache --zero-stats
       - run: meson setup builddir --force-fallback-for=fmt -Dcpp_std=c++${{ matrix.cxx_standard }}
+        env:
+          CXX: ccache g++
       - run: meson test -C builddir --print-errorlogs
+      # Printed rather than assumed: a cache that silently stops hitting looks exactly like one
+      # that works, only slower.
+      - run: ccache --show-stats
       - uses: actions/upload-artifact@v7
         if: failure()
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ fuzz-findings/
 
 # left behind by importing anything under scripts/
 __pycache__/
+
+# compiler cache, populated by the MinGW CI job
+.ccache/


### PR DESCRIPTION
The MinGW legs decide how long a CI run takes. From the last run before this change (`31063781825`):

| job | duration |
|---|---|
| **MinGW (C++23, 64bit)** | **233s** |
| MinGW (C++23, 32bit) | 190s |
| MinGW (C++17, 32bit) | 188s |
| MinGW (C++17, 64bit) | 186s |
| Windows (C++17, 64bit) | 97s |
| Linux (gcc, C++23, 32bit) | 91s |
| lint | 26s |

Every other job finished within 97s, and the run's wall clock (233s) was exactly the slowest MinGW job. Neither cause is the compiler being slow.

## Where the 233s went

Taken from the job's own step timings and log, not estimated:

**Setup — 82s, of which 63s was pacman.**

| phase | time |
|---|---|
| download + extract MSYS2 | 9s |
| restore package cache (hit, 138 MB) | 2s |
| first-time setup + gpg keyring | 5s |
| updating packages | 4s |
| **final system upgrade** | **59s** |
| save package cache | 4s |

The package cache was already hitting. The cost is `update: true`, a full `pacman -Syuu` against the runner image on every job of every run, upgrading things this build never loads — `bash-completion`, `curl`, `gnutls`, `gawk`.

**Build — 110s, of which 107s was compiling.**

```
17:31:55  [1/87] Compiling C++ object test/udm-test.exe.p/app_stacktrace.cpp.obj
17:33:44  1/1 unordered_dense:unit OK    1.99s
```

87 objects from scratch; the tests themselves run in two seconds.

## What changed

- **`update: false`.** The `install:` list is what the build needs and pins nothing, so those packages are still current — what goes away is upgrading everything else.
- **A compiler cache for MinGW.** Every other job in this workflow has had one since the matrix was rewritten (`ccache` on Linux and macOS, `sccache` for MSVC at `main.yml:147`); MinGW was the one left out. `hendrikmuhs/ccache-action`, which the others use, installs a Windows-native ccache that a msys2 shell cannot see, so this wires up msys2's own against `actions/cache`. The key is per arch and per standard, since objects aren't interchangeable across either.
- **`ccache --show-stats` after the build**, because a cache that quietly stops hitting looks exactly like one that works, only slower.

## Two caveats on reading the numbers

**This PR's own run will not show the gain.** The ccache starts empty and `update: false` changes the msys2 cache key, so both caches miss once. The comparison worth making is the *second* run on this branch, or the first run after merge.

**The pacman time is a trade, not free.** MinGW now builds against the runner image's msys2 rather than against the newest of everything. That was being tested incidentally and now isn't. If you'd rather keep it, the fix is a scheduled job that runs the MinGW matrix with `update: true` nightly, and I'd be happy to add that instead.

## Not done here

The MinGW matrix is 4 jobs (2 arches × 2 standards) and they run in parallel, so cutting it wouldn't improve wall clock — only runner-minutes. Left alone since it's coverage.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxhyeMXim7Pvb8SmYoEdBk)_