### PR TITLE
Fix allocator handling in segmented_vector (#104)

### DIFF
--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -571,6 +571,15 @@ public:
 
 private:
     using vec_alloc = typename std::allocator_traits<Allocator>::template rebind_alloc<pointer>;
+    using vec_alloc_traits = std::allocator_traits<vec_alloc>;
+
+    // The allocator lives in m_blocks, so these are what the assignment operators below act on --
+    // and what their noexcept specifications are written over, so that the condition and the
+    // promise cannot drift apart.
+    static constexpr bool propagates_on_copy_assign = vec_alloc_traits::propagate_on_container_copy_assignment::value;
+    static constexpr bool propagates_on_move_assign = vec_alloc_traits::propagate_on_container_move_assignment::value;
+    static constexpr bool allocators_always_equal = vec_alloc_traits::is_always_equal::value;
+
     std::vector<pointer, vec_alloc> m_blocks{};
     std::size_t m_size{};
 
@@ -790,7 +799,7 @@ public:
         : segmented_vector(std::move(other), other.get_allocator()) {}
 
     segmented_vector(segmented_vector const& other)
-        : m_blocks(std::allocator_traits<vec_alloc>::select_on_container_copy_construction(other.m_blocks.get_allocator())) {
+        : m_blocks(vec_alloc_traits::select_on_container_copy_construction(other.m_blocks.get_allocator())) {
         append_everything_from(other);
     }
 
@@ -799,16 +808,13 @@ public:
             return *this;
         }
         clear();
-        if constexpr (std::allocator_traits<vec_alloc>::propagate_on_container_copy_assignment::value) {
+        if constexpr (propagates_on_copy_assign) {
             if (m_blocks.get_allocator() != other.m_blocks.get_allocator()) {
-                // Everything still held was allocated through the old allocator, so it has to go
-                // back through that one before the new allocator is adopted.
+                // Everything still held has to go back through the old allocator before the new
+                // one is adopted. Copy assignment and not move: which of the two propagates is
+                // the inner vector's own pocca/pocma, and only pocca is known true here, so
+                // assigning a temporary would consult pocma and silently keep the old allocator.
                 dealloc();
-                m_blocks.clear();
-                // Copy assignment rather than move: which of the two propagates the allocator is
-                // the inner vector's own pocca/pocma, and only pocca is known true in this branch.
-                // Assigning a temporary here would move, consult pocma, and silently keep the old
-                // allocator -- which is how the code being fixed came to adopt the wrong one.
                 auto const empty_with_other_allocator = std::vector<pointer, vec_alloc>(other.m_blocks.get_allocator());
                 m_blocks = empty_with_other_allocator;
             }
@@ -818,29 +824,26 @@ public:
     }
 
     // Not unconditionally noexcept. When the allocator neither propagates nor compares equal --
-    // std::pmr::polymorphic_allocator, for one -- the elements have to be moved one at a time
-    // into memory this container allocates, and running out of it there used to terminate the
-    // process against a noexcept boundary rather than throw. std::vector spells the condition the
-    // same way.
-    auto operator=(segmented_vector&& other) noexcept(
-        std::allocator_traits<vec_alloc>::propagate_on_container_move_assignment::value ||
-        std::allocator_traits<vec_alloc>::is_always_equal::value) -> segmented_vector& {
+    // std::pmr::polymorphic_allocator, for one -- the elements are moved one at a time into memory
+    // this container allocates, so running out of it here has to be allowed to throw rather than
+    // terminate. std::vector spells the condition the same way.
+    auto operator=(segmented_vector&& other) noexcept(propagates_on_move_assign || allocators_always_equal)
+        -> segmented_vector& {
         if (this == &other) {
             return *this;
         }
         clear();
-        dealloc();
-        // Either the allocator comes along with the blocks, or it is already the same one: both
-        // mean the blocks can simply be taken over. std::vector's own move assignment does the
+        // Either the allocator comes along with the blocks or it is already the same one, and
+        // either way the blocks can be taken over; std::vector's own move assignment does the
         // propagating in the first case.
-        if (std::allocator_traits<vec_alloc>::propagate_on_container_move_assignment::value ||
-            other.get_allocator() == get_allocator()) {
+        if (propagates_on_move_assign || m_blocks.get_allocator() == other.m_blocks.get_allocator()) {
+            dealloc();
             m_blocks = std::move(other.m_blocks);
             m_size = std::exchange(other.m_size, {});
         } else {
-            // Keeps its own allocator, because nothing said to take other's: adopting it here is
-            // what used to make memory allocated from one arena get freed through another.
-            m_blocks.clear();
+            // Keeps its own allocator, because nothing said to take other's -- so the blocks it
+            // already holds came from that same allocator and are reused rather than handed back
+            // and immediately asked for again.
             append_everything_from(std::move(other));
         }
         return *this;

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -789,7 +789,8 @@ public:
     segmented_vector(segmented_vector&& other) noexcept
         : segmented_vector(std::move(other), other.get_allocator()) {}
 
-    segmented_vector(segmented_vector const& other) {
+    segmented_vector(segmented_vector const& other)
+        : m_blocks(std::allocator_traits<vec_alloc>::select_on_container_copy_construction(other.m_blocks.get_allocator())) {
         append_everything_from(other);
     }
 
@@ -798,19 +799,48 @@ public:
             return *this;
         }
         clear();
+        if constexpr (std::allocator_traits<vec_alloc>::propagate_on_container_copy_assignment::value) {
+            if (m_blocks.get_allocator() != other.m_blocks.get_allocator()) {
+                // Everything still held was allocated through the old allocator, so it has to go
+                // back through that one before the new allocator is adopted.
+                dealloc();
+                m_blocks.clear();
+                // Copy assignment rather than move: which of the two propagates the allocator is
+                // the inner vector's own pocca/pocma, and only pocca is known true in this branch.
+                // Assigning a temporary here would move, consult pocma, and silently keep the old
+                // allocator -- which is how the code being fixed came to adopt the wrong one.
+                auto const empty_with_other_allocator = std::vector<pointer, vec_alloc>(other.m_blocks.get_allocator());
+                m_blocks = empty_with_other_allocator;
+            }
+        }
         append_everything_from(other);
         return *this;
     }
 
-    auto operator=(segmented_vector&& other) noexcept -> segmented_vector& {
+    // Not unconditionally noexcept. When the allocator neither propagates nor compares equal --
+    // std::pmr::polymorphic_allocator, for one -- the elements have to be moved one at a time
+    // into memory this container allocates, and running out of it there used to terminate the
+    // process against a noexcept boundary rather than throw. std::vector spells the condition the
+    // same way.
+    auto operator=(segmented_vector&& other) noexcept(
+        std::allocator_traits<vec_alloc>::propagate_on_container_move_assignment::value ||
+        std::allocator_traits<vec_alloc>::is_always_equal::value) -> segmented_vector& {
+        if (this == &other) {
+            return *this;
+        }
         clear();
         dealloc();
-        if (other.get_allocator() == get_allocator()) {
+        // Either the allocator comes along with the blocks, or it is already the same one: both
+        // mean the blocks can simply be taken over. std::vector's own move assignment does the
+        // propagating in the first case.
+        if (std::allocator_traits<vec_alloc>::propagate_on_container_move_assignment::value ||
+            other.get_allocator() == get_allocator()) {
             m_blocks = std::move(other.m_blocks);
             m_size = std::exchange(other.m_size, {});
         } else {
-            // make sure to construct with other's allocator!
-            m_blocks = std::vector<pointer, vec_alloc>(vec_alloc(other.get_allocator()));
+            // Keeps its own allocator, because nothing said to take other's: adopting it here is
+            // what used to make memory allocated from one arena get freed through another.
+            m_blocks.clear();
             append_everything_from(std::move(other));
         }
         return *this;

--- a/test/meson.build
+++ b/test/meson.build
@@ -73,6 +73,7 @@ test_sources = [
     'unit/reserve_and_assign.cpp',
     'unit/reserve.cpp',
     'unit/segmented_vector.cpp',
+    'unit/segmented_vector_allocators.cpp',
     'unit/set_or_map_types.cpp',
     'unit/set.cpp',
     'unit/std_hash.cpp',

--- a/test/unit/segmented_vector_allocators.cpp
+++ b/test/unit/segmented_vector_allocators.cpp
@@ -2,9 +2,12 @@
 
 #include <app/doctest.h>
 
+#include <cstddef>
+#include <functional>
 #include <memory>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 // Allocator propagation in segmented_vector, from issue #104.
@@ -18,23 +21,23 @@ namespace {
 // Propagates on nothing and instances differ, which is how std::pmr::polymorphic_allocator behaves
 // -- the allocator this library supports and tests, and the reason issue #104's proposed
 // static_assert(pocma) fix cannot be applied here.
-template <typename T>
-struct sticky_allocator {
+template <typename T, typename Pocca = std::false_type>
+struct id_allocator {
     using value_type = T;
-    using propagate_on_container_copy_assignment = std::false_type;
+    using propagate_on_container_copy_assignment = Pocca;
     using propagate_on_container_move_assignment = std::false_type;
     using propagate_on_container_swap = std::false_type;
     using is_always_equal = std::false_type;
 
     int m_id = 0;
 
-    sticky_allocator() = default;
-    explicit sticky_allocator(int id)
+    id_allocator() = default;
+    explicit id_allocator(int id)
         : m_id(id) {}
 
     template <typename U>
     // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
-    sticky_allocator(sticky_allocator<U> const& other) noexcept
+    id_allocator(id_allocator<U, Pocca> const& other) noexcept
         : m_id(other.m_id) {}
 
     auto allocate(std::size_t n) -> T* {
@@ -45,38 +48,25 @@ struct sticky_allocator {
         std::allocator<T>{}.deallocate(p, n);
     }
 
-    friend auto operator==(sticky_allocator const& a, sticky_allocator const& b) noexcept -> bool {
+    friend auto operator==(id_allocator const& a, id_allocator const& b) noexcept -> bool {
         return a.m_id == b.m_id;
     }
 
-    friend auto operator!=(sticky_allocator const& a, sticky_allocator const& b) noexcept -> bool {
+    friend auto operator!=(id_allocator const& a, id_allocator const& b) noexcept -> bool {
         return !(a == b);
     }
-};
-
-// The same, except that it propagates on copy assignment, so the POCCA branch is reachable.
-template <typename T>
-struct copying_allocator : sticky_allocator<T> {
-    using propagate_on_container_copy_assignment = std::true_type;
-
-    using sticky_allocator<T>::sticky_allocator;
-
-    template <typename U>
-    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
-    copying_allocator(copying_allocator<U> const& other) noexcept
-        : sticky_allocator<T>(other.m_id) {}
 };
 
 template <typename Alloc>
 using vec_of = ankerl::unordered_dense::segmented_vector<int, Alloc, sizeof(int) * 4>;
 
-using sticky_vec = vec_of<sticky_allocator<int>>;
-using copying_vec = vec_of<copying_allocator<int>>;
+using sticky_vec = vec_of<id_allocator<int>>;
+using copying_vec = vec_of<id_allocator<int, std::true_type>>;
 using std_vec = vec_of<std::allocator<int>>;
 
 template <typename Vec>
-auto filled(typename Vec::allocator_type alloc, int count) -> Vec {
-    auto vec = Vec(alloc);
+auto filled(int allocator_id, int count) -> Vec {
+    auto vec = Vec(typename Vec::allocator_type(allocator_id));
     for (int i = 0; i < count; ++i) {
         vec.emplace_back(i);
     }
@@ -91,26 +81,35 @@ void require_holds(Vec const& vec, int count) {
     }
 }
 
-} // namespace
+template <typename Vec>
+void check_copy_assign(int expected_allocator_id) {
+    auto source = filled<Vec>(1, 10);
+    auto target = filled<Vec>(2, 3);
 
-// Move assignment between allocators that neither propagate nor compare equal has to move the
-// elements one at a time, and that allocates. It was noexcept anyway, so running out of memory
-// there terminated the process instead of throwing.
-TEST_CASE("segmented_vector_move_assign_noexcept_only_when_it_cannot_throw") {
-    static_assert(std::is_nothrow_move_assignable_v<std_vec>);
-    static_assert(std::is_nothrow_move_assignable_v<ankerl::unordered_dense::segmented_vector<std::string>>);
-    static_assert(!std::is_nothrow_move_assignable_v<sticky_vec>);
+    target = source;
 
-    // ... and the container built on it says the same thing, since that is what callers see.
-    using sticky_map = ankerl::unordered_dense::
-        segmented_map<int, int, ankerl::unordered_dense::hash<int>, std::equal_to<int>, sticky_allocator<std::pair<int, int>>>;
-    static_assert(!std::is_nothrow_move_assignable_v<sticky_map>);
-    static_assert(std::is_nothrow_move_assignable_v<ankerl::unordered_dense::segmented_map<int, int>>);
+    REQUIRE(target.get_allocator().m_id == expected_allocator_id);
+    require_holds(target, 10);
 }
 
+} // namespace
+
+// Move assignment between allocators that neither propagate nor compare equal moves the elements
+// one at a time, and that allocates. It was noexcept anyway, so running out of memory there
+// terminated the process instead of throwing.
+static_assert(std::is_nothrow_move_assignable_v<std_vec>);
+static_assert(std::is_nothrow_move_assignable_v<ankerl::unordered_dense::segmented_vector<std::string>>);
+static_assert(!std::is_nothrow_move_assignable_v<sticky_vec>);
+
+// ... and the container built on it says the same thing, since that is what callers see.
+using sticky_map = ankerl::unordered_dense::
+    segmented_map<int, int, ankerl::unordered_dense::hash<int>, std::equal_to<int>, id_allocator<std::pair<int, int>>>;
+static_assert(!std::is_nothrow_move_assignable_v<sticky_map>);
+static_assert(std::is_nothrow_move_assignable_v<ankerl::unordered_dense::segmented_map<int, int>>);
+
 TEST_CASE("segmented_vector_move_assign_keeps_its_own_allocator") {
-    auto source = filled<sticky_vec>(sticky_allocator<int>(1), 10);
-    auto target = filled<sticky_vec>(sticky_allocator<int>(2), 3);
+    auto source = filled<sticky_vec>(1, 10);
+    auto target = filled<sticky_vec>(2, 3);
 
     target = std::move(source);
 
@@ -121,8 +120,8 @@ TEST_CASE("segmented_vector_move_assign_keeps_its_own_allocator") {
 }
 
 TEST_CASE("segmented_vector_move_assign_between_equal_allocators_steals") {
-    auto source = filled<sticky_vec>(sticky_allocator<int>(7), 10);
-    auto target = filled<sticky_vec>(sticky_allocator<int>(7), 3);
+    auto source = filled<sticky_vec>(7, 10);
+    auto target = filled<sticky_vec>(7, 3);
 
     target = std::move(source);
 
@@ -132,7 +131,7 @@ TEST_CASE("segmented_vector_move_assign_between_equal_allocators_steals") {
 }
 
 TEST_CASE("segmented_vector_copy_construction_asks_the_allocator") {
-    auto source = filled<sticky_vec>(sticky_allocator<int>(5), 10);
+    auto source = filled<sticky_vec>(5, 10);
 
     auto copy = source;
 
@@ -144,38 +143,28 @@ TEST_CASE("segmented_vector_copy_construction_asks_the_allocator") {
 }
 
 TEST_CASE("segmented_vector_copy_construction_with_an_explicit_allocator") {
-    auto source = filled<sticky_vec>(sticky_allocator<int>(5), 10);
+    auto source = filled<sticky_vec>(5, 10);
 
-    auto copy = sticky_vec(source, sticky_allocator<int>(9));
+    auto copy = sticky_vec(source, id_allocator<int>(9));
 
     REQUIRE(copy.get_allocator().m_id == 9);
     require_holds(copy, 10);
 }
 
 TEST_CASE("segmented_vector_copy_assign_propagates_only_when_asked") {
+    // Named source, and not a temporary: assigning a prvalue would pick move assignment and stop
+    // testing what the case is called.
     SUBCASE("without pocca the target keeps its allocator") {
-        auto source = filled<sticky_vec>(sticky_allocator<int>(1), 10);
-        auto target = filled<sticky_vec>(sticky_allocator<int>(2), 3);
-
-        target = source;
-
-        REQUIRE(target.get_allocator().m_id == 2);
-        require_holds(target, 10);
+        check_copy_assign<sticky_vec>(2);
     }
 
     SUBCASE("with pocca it takes the source's") {
-        auto source = filled<copying_vec>(copying_allocator<int>(1), 10);
-        auto target = filled<copying_vec>(copying_allocator<int>(2), 3);
-
-        target = source;
-
-        REQUIRE(target.get_allocator().m_id == 1);
-        require_holds(target, 10);
+        check_copy_assign<copying_vec>(1);
     }
 }
 
 TEST_CASE("segmented_vector_self_assignment_keeps_the_contents") {
-    auto vec = filled<sticky_vec>(sticky_allocator<int>(3), 10);
+    auto vec = filled<sticky_vec>(3, 10);
 
     auto& alias = vec;
     vec = alias;
@@ -183,10 +172,9 @@ TEST_CASE("segmented_vector_self_assignment_keeps_the_contents") {
     REQUIRE(vec.get_allocator().m_id == 3);
 }
 
-// The move constructor reads other's allocator to build itself with. It used to read its own,
-// before its own existed; that has since been fixed, and this keeps it fixed.
+// Pins a fix that predates this change: the move constructor builds itself from other's allocator.
 TEST_CASE("segmented_vector_move_construction_takes_the_source_allocator") {
-    auto source = filled<sticky_vec>(sticky_allocator<int>(4), 10);
+    auto source = filled<sticky_vec>(4, 10);
 
     auto moved = std::move(source);
 

--- a/test/unit/segmented_vector_allocators.cpp
+++ b/test/unit/segmented_vector_allocators.cpp
@@ -1,0 +1,195 @@
+#include <ankerl/unordered_dense.h>
+
+#include <app/doctest.h>
+
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+// Allocator propagation in segmented_vector, from issue #104.
+//
+// std::allocator makes none of this observable: it is stateless, every instance compares equal, and
+// is_always_equal is true, so every branch that depends on "are these two allocators the same" is
+// dead. These two carry an id instead, so taking the wrong one shows up as a value rather than as
+// undefined behaviour.
+namespace {
+
+// Propagates on nothing and instances differ, which is how std::pmr::polymorphic_allocator behaves
+// -- the allocator this library supports and tests, and the reason issue #104's proposed
+// static_assert(pocma) fix cannot be applied here.
+template <typename T>
+struct sticky_allocator {
+    using value_type = T;
+    using propagate_on_container_copy_assignment = std::false_type;
+    using propagate_on_container_move_assignment = std::false_type;
+    using propagate_on_container_swap = std::false_type;
+    using is_always_equal = std::false_type;
+
+    int m_id = 0;
+
+    sticky_allocator() = default;
+    explicit sticky_allocator(int id)
+        : m_id(id) {}
+
+    template <typename U>
+    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+    sticky_allocator(sticky_allocator<U> const& other) noexcept
+        : m_id(other.m_id) {}
+
+    auto allocate(std::size_t n) -> T* {
+        return std::allocator<T>{}.allocate(n);
+    }
+
+    void deallocate(T* p, std::size_t n) {
+        std::allocator<T>{}.deallocate(p, n);
+    }
+
+    friend auto operator==(sticky_allocator const& a, sticky_allocator const& b) noexcept -> bool {
+        return a.m_id == b.m_id;
+    }
+
+    friend auto operator!=(sticky_allocator const& a, sticky_allocator const& b) noexcept -> bool {
+        return !(a == b);
+    }
+};
+
+// The same, except that it propagates on copy assignment, so the POCCA branch is reachable.
+template <typename T>
+struct copying_allocator : sticky_allocator<T> {
+    using propagate_on_container_copy_assignment = std::true_type;
+
+    using sticky_allocator<T>::sticky_allocator;
+
+    template <typename U>
+    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+    copying_allocator(copying_allocator<U> const& other) noexcept
+        : sticky_allocator<T>(other.m_id) {}
+};
+
+template <typename Alloc>
+using vec_of = ankerl::unordered_dense::segmented_vector<int, Alloc, sizeof(int) * 4>;
+
+using sticky_vec = vec_of<sticky_allocator<int>>;
+using copying_vec = vec_of<copying_allocator<int>>;
+using std_vec = vec_of<std::allocator<int>>;
+
+template <typename Vec>
+auto filled(typename Vec::allocator_type alloc, int count) -> Vec {
+    auto vec = Vec(alloc);
+    for (int i = 0; i < count; ++i) {
+        vec.emplace_back(i);
+    }
+    return vec;
+}
+
+template <typename Vec>
+void require_holds(Vec const& vec, int count) {
+    REQUIRE(vec.size() == static_cast<std::size_t>(count));
+    for (int i = 0; i < count; ++i) {
+        REQUIRE(vec[static_cast<std::size_t>(i)] == i);
+    }
+}
+
+} // namespace
+
+// Move assignment between allocators that neither propagate nor compare equal has to move the
+// elements one at a time, and that allocates. It was noexcept anyway, so running out of memory
+// there terminated the process instead of throwing.
+TEST_CASE("segmented_vector_move_assign_noexcept_only_when_it_cannot_throw") {
+    static_assert(std::is_nothrow_move_assignable_v<std_vec>);
+    static_assert(std::is_nothrow_move_assignable_v<ankerl::unordered_dense::segmented_vector<std::string>>);
+    static_assert(!std::is_nothrow_move_assignable_v<sticky_vec>);
+
+    // ... and the container built on it says the same thing, since that is what callers see.
+    using sticky_map = ankerl::unordered_dense::
+        segmented_map<int, int, ankerl::unordered_dense::hash<int>, std::equal_to<int>, sticky_allocator<std::pair<int, int>>>;
+    static_assert(!std::is_nothrow_move_assignable_v<sticky_map>);
+    static_assert(std::is_nothrow_move_assignable_v<ankerl::unordered_dense::segmented_map<int, int>>);
+}
+
+TEST_CASE("segmented_vector_move_assign_keeps_its_own_allocator") {
+    auto source = filled<sticky_vec>(sticky_allocator<int>(1), 10);
+    auto target = filled<sticky_vec>(sticky_allocator<int>(2), 3);
+
+    target = std::move(source);
+
+    // Nothing propagates, so the target keeps the allocator it was built with. It used to adopt
+    // the source's, which meant memory allocated from one arena was later freed through another.
+    REQUIRE(target.get_allocator().m_id == 2);
+    require_holds(target, 10);
+}
+
+TEST_CASE("segmented_vector_move_assign_between_equal_allocators_steals") {
+    auto source = filled<sticky_vec>(sticky_allocator<int>(7), 10);
+    auto target = filled<sticky_vec>(sticky_allocator<int>(7), 3);
+
+    target = std::move(source);
+
+    REQUIRE(target.get_allocator().m_id == 7);
+    require_holds(target, 10);
+    REQUIRE(source.empty()); // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
+}
+
+TEST_CASE("segmented_vector_copy_construction_asks_the_allocator") {
+    auto source = filled<sticky_vec>(sticky_allocator<int>(5), 10);
+
+    auto copy = source;
+
+    // select_on_container_copy_construction defaults to handing back a copy, so this one inherits
+    // the id. The copy constructor used to default construct its allocator and lose it.
+    REQUIRE(copy.get_allocator().m_id == 5);
+    require_holds(copy, 10);
+    require_holds(source, 10);
+}
+
+TEST_CASE("segmented_vector_copy_construction_with_an_explicit_allocator") {
+    auto source = filled<sticky_vec>(sticky_allocator<int>(5), 10);
+
+    auto copy = sticky_vec(source, sticky_allocator<int>(9));
+
+    REQUIRE(copy.get_allocator().m_id == 9);
+    require_holds(copy, 10);
+}
+
+TEST_CASE("segmented_vector_copy_assign_propagates_only_when_asked") {
+    SUBCASE("without pocca the target keeps its allocator") {
+        auto source = filled<sticky_vec>(sticky_allocator<int>(1), 10);
+        auto target = filled<sticky_vec>(sticky_allocator<int>(2), 3);
+
+        target = source;
+
+        REQUIRE(target.get_allocator().m_id == 2);
+        require_holds(target, 10);
+    }
+
+    SUBCASE("with pocca it takes the source's") {
+        auto source = filled<copying_vec>(copying_allocator<int>(1), 10);
+        auto target = filled<copying_vec>(copying_allocator<int>(2), 3);
+
+        target = source;
+
+        REQUIRE(target.get_allocator().m_id == 1);
+        require_holds(target, 10);
+    }
+}
+
+TEST_CASE("segmented_vector_self_assignment_keeps_the_contents") {
+    auto vec = filled<sticky_vec>(sticky_allocator<int>(3), 10);
+
+    auto& alias = vec;
+    vec = alias;
+    require_holds(vec, 10);
+    REQUIRE(vec.get_allocator().m_id == 3);
+}
+
+// The move constructor reads other's allocator to build itself with. It used to read its own,
+// before its own existed; that has since been fixed, and this keeps it fixed.
+TEST_CASE("segmented_vector_move_construction_takes_the_source_allocator") {
+    auto source = filled<sticky_vec>(sticky_allocator<int>(4), 10);
+
+    auto moved = std::move(source);
+
+    REQUIRE(moved.get_allocator().m_id == 4);
+    require_holds(moved, 10);
+}


### PR DESCRIPTION
Fixes #104, reported December 2023. Three of its four points still stand; I verified each against the current header rather than taking the report at face value.

## `operator=(segmented_vector&&)` was `noexcept` and could allocate

```cpp
auto operator=(segmented_vector&& other) noexcept -> segmented_vector& {   // :805
    ...
    } else {
        m_blocks = std::vector<pointer, vec_alloc>(vec_alloc(other.get_allocator()));
        append_everything_from(std::move(other));   // allocates, inside noexcept
    }
```

When the allocator neither propagates nor compares equal, the elements are moved one at a time into memory this container allocates — so OOM there terminated the process against a `noexcept` boundary instead of throwing. It is now `noexcept` exactly when it cannot throw, which is the condition `std::vector` uses: `pocma`, or an allocator that is always equal.

**I did not apply the fix the issue proposes.** It suggests `static_assert(pocma)`, but `std::pmr::polymorphic_allocator` has `pocma == false`, and this library supports it — `ankerl::unordered_dense::pmr::segmented_map` exists and is tested in `pmr_move_with_allocators.cpp`. That assert would delete pmr support. Every allocator whose propagation is worth testing looks like that one, which is why the new tests use an allocator shaped the same way.

That same branch also **adopted `other`'s allocator**, so blocks allocated from one arena could be freed through another. Nothing asked for it to propagate, so it keeps its own now.

## Copy construction lost a stateful allocator

`segmented_vector(segmented_vector const&)` default-constructed `m_blocks`, discarding the source's allocator entirely. It now asks `select_on_container_copy_construction`, which hands back a copy by default and something else for allocators like pmr's that want it.

## Copy assignment ignored `pocca`

Now honoured, deallocating through the old allocator before adopting the new one.

There's a trap in doing that which is worth naming, because **the code being fixed fell into it and so did my first attempt**: assigning a temporary vector to `m_blocks` is a *move* assignment, so which allocator survives is decided by `pocma`, not `pocca`. With `pocma` false the old allocator silently stays. The new one has to arrive by *copy* assignment for `pocca` to be consulted. A test caught it.

## Already fixed, now pinned

The issue's fourth point — `segmented_vector(segmented_vector&&)` reading its own `get_allocator()` before it existed — was fixed at some point since; `:790` reads `other.get_allocator()`. There's now a test so it stays fixed.

## Tests

Nine cases in `test/unit/segmented_vector_allocators.cpp`. `std::allocator` makes none of this observable — stateless and always equal, so every branch asking whether two allocators differ is dead — so the tests use allocators carrying an id, and the wrong choice shows up as a value instead of as undefined behaviour. Two are `static_assert`s on the `noexcept` specification, which is what fails against the unfixed header:

```
error: static assertion failed due to requirement
  '!std::is_nothrow_move_assignable_v<segmented_vector<int, sticky_allocator<int>, 16>>'
```

Verified with clang and gcc at C++17, and under `address,undefined` — the build where freeing through the wrong allocator would show up. Full suite green on all three.

Not benchmarked: the change is confined to `segmented_vector`'s copy and move assignment, which `bench_quick_overall_udm` doesn't exercise (it measures `map`, backed by `std::vector`, not `segmented_map`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxhyeMXim7Pvb8SmYoEdBk)_