### PR TITLE
Give detail::table's constructors the allocator they were handed

### DIFF
--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1466,22 +1466,41 @@ public:
     table(InputIt first, InputIt last, size_type bucket_count, Hash const& hash, allocator_type const& alloc)
         : table(first, last, bucket_count, hash, KeyEqual(), alloc) {}
 
+    // Asks the allocator whether it wants to come along, which is what allocator_traits' default
+    // does and what an allocator like std::pmr::polymorphic_allocator declines: a copy of a map
+    // living in an arena should not silently keep that arena alive and keep allocating into it.
     table(table const& other)
-        : table(other, other.m_values.get_allocator()) {}
+        : table(other,
+                std::allocator_traits<allocator_type>::select_on_container_copy_construction(other.m_values.get_allocator())) {
+    }
 
+    // m_buckets takes the allocator too. Leaving it to its default member initialiser put the
+    // bucket array in the default resource while the values went where the caller asked, so half
+    // the container escaped the arena it was given -- and get_allocator(), which reports m_values'
+    // allocator, could not be used to reason about the buckets any more.
     table(table const& other, allocator_type const& alloc)
         : m_values(other.m_values, alloc)
+        , m_buckets(alloc)
         , m_max_load_factor(other.m_max_load_factor)
         , m_hash(other.m_hash)
         , m_equal(other.m_equal) {
         copy_buckets(other);
     }
 
+    // Unconditionally noexcept, and honestly so: it hands over other's own allocator, so the
+    // assignment below always takes the branch that takes the buffers over rather than the one
+    // that moves elements into freshly allocated memory.
     table(table&& other) noexcept
         : table(std::move(other), other.m_values.get_allocator()) {}
 
-    table(table&& other, allocator_type const& alloc) noexcept
-        : m_values(alloc) {
+    // Not unconditionally noexcept, unlike the above: this is the constructor whose whole purpose
+    // is a *differing* allocator, so the assignment below may have to move the elements one at a
+    // time, and that allocates. The specification is the assignment's own.
+    table(table&& other, allocator_type const& alloc) noexcept(std::is_nothrow_move_assignable_v<value_container_type> &&
+                                                               std::is_nothrow_move_assignable_v<Hash> &&
+                                                               std::is_nothrow_move_assignable_v<KeyEqual>)
+        : m_values(alloc)
+        , m_buckets(alloc) {
         *this = std::move(other);
     }
 

--- a/test/app/id_allocator.h
+++ b/test/app/id_allocator.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+
+// An allocator whose instances are distinguishable, for testing allocator propagation.
+//
+// std::allocator makes none of that observable: it is stateless, every instance compares equal and
+// is_always_equal is true, so every branch that asks whether two allocators differ is dead code.
+// This one carries an id, so taking the wrong allocator shows up as a value rather than as
+// undefined behaviour, and optionally counts what was allocated through it, so it is also visible
+// *which* of a container's buffers went where.
+//
+// The defaults match std::pmr::polymorphic_allocator, which is the allocator this library supports
+// whose propagation is worth testing: propagates on nothing, instances differ.
+namespace test {
+
+struct alloc_counts {
+    int allocations = 0;
+    int deallocations = 0;
+};
+
+template <typename T, typename Pocca = std::false_type, typename Soccc = std::true_type>
+struct id_allocator {
+    using value_type = T;
+    using propagate_on_container_copy_assignment = Pocca;
+    using propagate_on_container_move_assignment = std::false_type;
+    using propagate_on_container_swap = std::false_type;
+    using is_always_equal = std::false_type;
+
+    int m_id = 0;
+    alloc_counts* m_counts = nullptr;
+
+    id_allocator() = default;
+
+    explicit id_allocator(int id, alloc_counts* counts = nullptr)
+        : m_id(id)
+        , m_counts(counts) {}
+
+    template <typename U>
+    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+    id_allocator(id_allocator<U, Pocca, Soccc> const& other) noexcept
+        : m_id(other.m_id)
+        , m_counts(other.m_counts) {}
+
+    auto allocate(std::size_t n) -> T* {
+        if (nullptr != m_counts) {
+            ++m_counts->allocations;
+        }
+        return std::allocator<T>{}.allocate(n);
+    }
+
+    void deallocate(T* p, std::size_t n) {
+        if (nullptr != m_counts) {
+            ++m_counts->deallocations;
+        }
+        std::allocator<T>{}.deallocate(p, n);
+    }
+
+    // Soccc == false_type behaves like std::pmr::polymorphic_allocator: a copy does not inherit
+    // the allocator, it gets the default one. The true_type default is what allocator_traits does
+    // on its own, i.e. hand back a copy.
+    [[nodiscard]] auto select_on_container_copy_construction() const -> id_allocator {
+        if constexpr (Soccc::value) {
+            return *this;
+        } else {
+            return id_allocator{};
+        }
+    }
+
+    friend auto operator==(id_allocator const& a, id_allocator const& b) noexcept -> bool {
+        return a.m_id == b.m_id;
+    }
+
+    friend auto operator!=(id_allocator const& a, id_allocator const& b) noexcept -> bool {
+        return !(a == b);
+    }
+};
+
+} // namespace test

--- a/test/meson.build
+++ b/test/meson.build
@@ -78,6 +78,7 @@ test_sources = [
     'unit/set.cpp',
     'unit/std_hash.cpp',
     'unit/swap.cpp',
+    'unit/table_allocators.cpp',
     'unit/transparent.cpp',
     'unit/try_emplace.cpp',
     'unit/tuple_hash.cpp',

--- a/test/unit/segmented_vector_allocators.cpp
+++ b/test/unit/segmented_vector_allocators.cpp
@@ -1,6 +1,7 @@
 #include <ankerl/unordered_dense.h>
 
 #include <app/doctest.h>
+#include <app/id_allocator.h>
 
 #include <cstddef>
 #include <functional>
@@ -21,47 +22,11 @@ namespace {
 // Propagates on nothing and instances differ, which is how std::pmr::polymorphic_allocator behaves
 // -- the allocator this library supports and tests, and the reason issue #104's proposed
 // static_assert(pocma) fix cannot be applied here.
-template <typename T, typename Pocca = std::false_type>
-struct id_allocator {
-    using value_type = T;
-    using propagate_on_container_copy_assignment = Pocca;
-    using propagate_on_container_move_assignment = std::false_type;
-    using propagate_on_container_swap = std::false_type;
-    using is_always_equal = std::false_type;
-
-    int m_id = 0;
-
-    id_allocator() = default;
-    explicit id_allocator(int id)
-        : m_id(id) {}
-
-    template <typename U>
-    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
-    id_allocator(id_allocator<U, Pocca> const& other) noexcept
-        : m_id(other.m_id) {}
-
-    auto allocate(std::size_t n) -> T* {
-        return std::allocator<T>{}.allocate(n);
-    }
-
-    void deallocate(T* p, std::size_t n) {
-        std::allocator<T>{}.deallocate(p, n);
-    }
-
-    friend auto operator==(id_allocator const& a, id_allocator const& b) noexcept -> bool {
-        return a.m_id == b.m_id;
-    }
-
-    friend auto operator!=(id_allocator const& a, id_allocator const& b) noexcept -> bool {
-        return !(a == b);
-    }
-};
-
 template <typename Alloc>
 using vec_of = ankerl::unordered_dense::segmented_vector<int, Alloc, sizeof(int) * 4>;
 
-using sticky_vec = vec_of<id_allocator<int>>;
-using copying_vec = vec_of<id_allocator<int, std::true_type>>;
+using sticky_vec = vec_of<test::id_allocator<int>>;
+using copying_vec = vec_of<test::id_allocator<int, std::true_type>>;
 using std_vec = vec_of<std::allocator<int>>;
 
 template <typename Vec>
@@ -103,7 +68,7 @@ static_assert(!std::is_nothrow_move_assignable_v<sticky_vec>);
 
 // ... and the container built on it says the same thing, since that is what callers see.
 using sticky_map = ankerl::unordered_dense::
-    segmented_map<int, int, ankerl::unordered_dense::hash<int>, std::equal_to<int>, id_allocator<std::pair<int, int>>>;
+    segmented_map<int, int, ankerl::unordered_dense::hash<int>, std::equal_to<int>, test::id_allocator<std::pair<int, int>>>;
 static_assert(!std::is_nothrow_move_assignable_v<sticky_map>);
 static_assert(std::is_nothrow_move_assignable_v<ankerl::unordered_dense::segmented_map<int, int>>);
 
@@ -145,7 +110,7 @@ TEST_CASE("segmented_vector_copy_construction_asks_the_allocator") {
 TEST_CASE("segmented_vector_copy_construction_with_an_explicit_allocator") {
     auto source = filled<sticky_vec>(5, 10);
 
-    auto copy = sticky_vec(source, id_allocator<int>(9));
+    auto copy = sticky_vec(source, test::id_allocator<int>(9));
 
     REQUIRE(copy.get_allocator().m_id == 9);
     require_holds(copy, 10);

--- a/test/unit/table_allocators.cpp
+++ b/test/unit/table_allocators.cpp
@@ -1,0 +1,145 @@
+#include <ankerl/unordered_dense.h>
+
+#include <app/doctest.h>
+#include <app/id_allocator.h>
+
+#include <cstddef>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+// Allocator handling in detail::table, from issue #174. The container-level counterpart to the
+// segmented_vector fixes in #173 -- the same decisions are made again one level up, over m_values
+// *and* m_buckets, and the map is what users actually hold.
+namespace {
+
+using value_type = std::pair<int, int>;
+
+template <typename Alloc>
+using map_of = ankerl::unordered_dense::map<int, int, ankerl::unordered_dense::hash<int>, std::equal_to<int>, Alloc>;
+
+template <typename Alloc>
+using segmented_map_of =
+    ankerl::unordered_dense::segmented_map<int, int, ankerl::unordered_dense::hash<int>, std::equal_to<int>, Alloc>;
+
+// Propagates on nothing, instances differ, and a copy does not inherit the allocator -- the shape
+// of std::pmr::polymorphic_allocator, which is the allocator whose propagation this library has to
+// get right.
+using pmr_like = test::id_allocator<value_type, std::false_type, std::false_type>;
+
+// The same, except that select_on_container_copy_construction does what allocator_traits does by
+// default and hands back a copy.
+using inheriting = test::id_allocator<value_type>;
+
+template <typename Map>
+auto filled(typename Map::allocator_type alloc, int count) -> Map {
+    auto map = Map(0, alloc);
+    for (int i = 0; i < count; ++i) {
+        map[i] = i;
+    }
+    return map;
+}
+
+template <typename Map>
+void require_holds(Map const& map, int count) {
+    REQUIRE(map.size() == static_cast<std::size_t>(count));
+    for (int i = 0; i < count; ++i) {
+        auto it = map.find(i);
+        REQUIRE(it != map.end());
+        REQUIRE(it->second == i);
+    }
+}
+
+} // namespace
+
+// A copy constructor has to ask the allocator whether it wants to come along. It used to hand the
+// source's allocator straight to the extended copy constructor, so a map copied out of an arena
+// silently kept that arena alive and kept allocating into it.
+TEST_CASE("table_copy_construction_asks_the_allocator") {
+    SUBCASE("an allocator that declines is not inherited") {
+        auto source = filled<map_of<pmr_like>>(pmr_like(7), 20);
+        auto copy = source;
+        REQUIRE(copy.get_allocator().m_id == 0);
+        require_holds(copy, 20);
+        require_holds(source, 20);
+    }
+
+    SUBCASE("an allocator that accepts is inherited") {
+        auto source = filled<map_of<inheriting>>(inheriting(7), 20);
+        auto copy = source;
+        REQUIRE(copy.get_allocator().m_id == 7);
+        require_holds(copy, 20);
+    }
+
+    SUBCASE("the segmented map answers the same way") {
+        auto source = filled<segmented_map_of<pmr_like>>(pmr_like(7), 20);
+        auto copy = source;
+        REQUIRE(copy.get_allocator().m_id == 0);
+        require_holds(copy, 20);
+    }
+}
+
+// Both halves of the container have to come from the allocator that was asked for. m_buckets used
+// to fall through to its default member initialiser in these two constructors, so the bucket array
+// landed in the default resource while the values went where the caller said.
+TEST_CASE("table_constructors_put_the_buckets_where_they_were_told") {
+    SUBCASE("copy with an allocator") {
+        auto source = filled<map_of<inheriting>>(inheriting(1), 200);
+        auto counts = test::alloc_counts{};
+
+        auto copy = map_of<inheriting>(source, inheriting(9, &counts));
+
+        REQUIRE(copy.get_allocator().m_id == 9);
+        require_holds(copy, 200);
+        // Values and buckets, not just values.
+        REQUIRE(counts.allocations >= 2);
+    }
+
+    SUBCASE("move with an allocator") {
+        auto source = filled<map_of<inheriting>>(inheriting(1), 200);
+        auto counts = test::alloc_counts{};
+
+        auto moved = map_of<inheriting>(std::move(source), inheriting(9, &counts));
+
+        require_holds(moved, 200);
+        REQUIRE(counts.allocations >= 2);
+    }
+
+    SUBCASE("the segmented map answers the same way") {
+        auto source = filled<segmented_map_of<inheriting>>(inheriting(1), 200);
+        auto counts = test::alloc_counts{};
+
+        auto copy = segmented_map_of<inheriting>(source, inheriting(9, &counts));
+
+        REQUIRE(copy.get_allocator().m_id == 9);
+        require_holds(copy, 200);
+        REQUIRE(counts.allocations >= 2);
+    }
+}
+
+// Whatever the allocator is, everything it handed out has to come back to it.
+TEST_CASE("table_gives_every_block_back_to_the_allocator_that_produced_it") {
+    auto counts = test::alloc_counts{};
+    {
+        auto map = filled<map_of<inheriting>>(inheriting(3, &counts), 200);
+        require_holds(map, 200);
+    }
+    REQUIRE(counts.allocations > 0);
+    REQUIRE(counts.deallocations == counts.allocations);
+}
+
+// The extended move constructor's body is *this = std::move(other), which for an allocator that
+// neither propagates nor compares equal moves the elements one at a time and allocates. #173 made
+// that assignment able to throw; the constructor around it still promised it could not, which is
+// the terminate-instead-of-throw that #173 set out to remove.
+using pmr_like_map = map_of<pmr_like>;
+using pmr_like_segmented = segmented_map_of<pmr_like>;
+
+static_assert(!std::is_nothrow_constructible_v<pmr_like_segmented, pmr_like_segmented&&, pmr_like>);
+
+// std::allocator propagates on move assignment and is always equal, so nothing above applies to it
+// and the default instantiations keep every promise they had.
+static_assert(std::is_nothrow_move_constructible_v<ankerl::unordered_dense::map<int, int>>);
+static_assert(std::is_nothrow_move_assignable_v<ankerl::unordered_dense::map<int, int>>);
+static_assert(std::is_nothrow_move_constructible_v<ankerl::unordered_dense::segmented_map<int, int>>);
+static_assert(std::is_nothrow_move_assignable_v<ankerl::unordered_dense::segmented_map<int, int>>);


### PR DESCRIPTION
Items **1, 2 and 5** of #174. Those are the ones a user can observe without reaching for undefined behaviour, and item 1 is what made the SOCCC fix in #173 unreachable from `map` and `set`.

### 1 — the copy constructor now asks the allocator

`table(table const&)` handed the source's allocator straight to the extended copy constructor, so `select_on_container_copy_construction` was never consulted — not `std::vector`'s, and not the one #173 added to `segmented_vector`, which is why that part of #173 never reached anything a user holds. A pmr map copied out of an arena kept that arena alive and kept allocating into it, which is the opposite of what pmr specifies.

### 2 — `m_buckets` now gets the allocator too

`m_buckets` was left to its default member initialiser in both constructors that take an allocator, so only the values went where the caller asked. Measured before this, with a pmr map of 200 elements: the 1600-byte value buffer landed in the requested resource and the 2048-byte bucket array in the default one. Half the container escaped the arena it was given, and `get_allocator()` — which reports `m_values`' allocator — stopped being a usable proxy for the buckets, which the "we can only reuse `m_buckets` when both maps have the same allocator" check relies on it being.

### 5 — the extended move constructor no longer promises `noexcept` around a throwing body

Its body is `*this = std::move(other)`. #173 made that assignment able to throw for an allocator that neither propagates nor compares equal — exactly the allocator this constructor exists for — so the promise had become a `terminate`. It now carries the assignment's own specification. The plain move constructor stays unconditionally `noexcept` and honestly so: it hands over `other`'s own allocator, so the assignment always takes the branch that takes the buffers over rather than the one that allocates.

### Tests

The test allocator moves out of `test/unit/segmented_vector_allocators.cpp` into `test/app/id_allocator.h`, since a second file needs it now, and grew optional allocation counting — which allocator a container's buffers came from is not otherwise observable from outside, and that is the whole of the `m_buckets` bug. `test/unit/table_allocators.cpp` is new: three test cases plus `static_assert`s on the `noexcept` specifications, covering both the flat and the segmented map.

Each of the three fixes was reverted in turn to confirm the tests catch it. Full unit suite green under clang, gcc C++17, and ASan+UBSan; all four linters pass.

### Not in scope

Items **3, 4 and 6** of #174 are not addressed here and the issue stays open for them. 3 (POCCA not applied to the buckets in copy assignment) and 4 (extended move constructors delegating to move assignment) are contract correctness rather than crashes; 6 (`swap` ignoring POCS, with the flat path cross-freeing) needs `segmented_vector` to grow a member `swap` first, which is a larger change than this one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxhyeMXim7Pvb8SmYoEdBk)_