### PR TITLE
Allocate the buckets on the first insert, not in the constructor

### DIFF
--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1149,9 +1149,9 @@ private:
     void copy_buckets(table const& other) {
         // assumes m_values has already the correct data copied over.
         if (empty()) {
-            // when empty, at least allocate an initial buckets and clear them.
-            allocate_buckets_from_shift();
-            clear_buckets();
+            // Nothing to index, so stay in the state a default constructed table is in and let the
+            // first insert allocate. Copying an empty table therefore allocates nothing either.
+            m_shifts = initial_shifts;
         } else {
             m_shifts = other.m_shifts;
             allocate_buckets_from_shift();
@@ -1200,7 +1200,28 @@ private:
         }
     }
 
+    // The bucket array is not allocated until the first element goes in, so that a default
+    // constructed table does not allocate. Every path that probes the buckets either returns early
+    // while the table is empty (do_find, do_erase_key), or needs an iterator into m_values and so
+    // cannot be reached in this state (erase, extract, replace_key), or calls this first -- which
+    // is the three insert entry points, the only ones that reach the buckets without a prior
+    // emptiness check.
+    void allocate_buckets_if_none() {
+        if (ANKERL_UNORDERED_DENSE_UNLIKELY(0 == bucket_count()))
+            ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
+                allocate_buckets_from_shift();
+                clear_buckets();
+            }
+    }
+
     void clear_buckets() {
+        // Reachable now that a table can have no buckets at all -- extract() clears them on the way
+        // out whether or not there are any. data() is null in that state, and memset's pointer has
+        // to be valid even for a zero length. Neither sanitizer in CI objects, so this is on the
+        // language rule rather than on a diagnostic.
+        if (0 == bucket_count()) {
+            return;
+        }
         if constexpr (IsSegmented || !std::is_same_v<BucketContainer, default_container_t>) {
             for (auto&& e : m_buckets) {
                 std::memset(&e, 0, sizeof(e));
@@ -1336,6 +1357,7 @@ private:
 
     template <typename K, typename... Args>
     auto do_try_emplace(K&& key, Args&&... args) -> std::pair<iterator, bool> {
+        allocate_buckets_if_none();
         auto hash = mixed_hash(key);
         auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
         auto bucket_idx = bucket_idx_from_hash(hash);
@@ -1427,11 +1449,11 @@ public:
         , m_buckets(alloc_or_container)
         , m_hash(hash)
         , m_equal(equal) {
+        // No bucket_count asked for means no buckets yet: the first insert allocates them. See
+        // allocate_buckets_if_none(). A default constructed table therefore costs no allocation at
+        // all, so one can sit in a scope that may never use it without paying for it.
         if (0 != bucket_count) {
             reserve(bucket_count);
-        } else {
-            allocate_buckets_from_shift();
-            clear_buckets();
         }
     }
 
@@ -1555,8 +1577,10 @@ public:
                 m_max_load_factor = std::exchange(other.m_max_load_factor, default_max_load_factor);
                 m_hash = std::exchange(other.m_hash, {});
                 m_equal = std::exchange(other.m_equal, {});
-                other.allocate_buckets_from_shift();
-                other.clear_buckets();
+                // The exchanges above leave "other" exactly as a default constructed table looks,
+                // so it is already usable and does not need buckets handed back to it. It used to
+                // get a freshly allocated set here, which is an allocation -- and a way to throw --
+                // inside an operation that is otherwise noexcept and needs neither.
             } else {
                 // set max_load_factor *before* copying the other's buckets, so we have the same
                 // behavior
@@ -1790,6 +1814,7 @@ public:
               typename KE = KeyEqual,
               std::enable_if_t<!is_map_v<Q> && is_transparent_v<H, KE>, bool> = true>
     auto emplace(K&& key) -> std::pair<iterator, bool> {
+        allocate_buckets_if_none();
         auto hash = mixed_hash(key);
         auto dist_and_fingerprint = dist_and_fingerprint_from_hash(hash);
         auto bucket_idx = bucket_idx_from_hash(hash);
@@ -1810,6 +1835,8 @@ public:
 
     template <class... Args>
     auto emplace(Args&&... args) -> std::pair<iterator, bool> {
+        allocate_buckets_if_none();
+
         // we have to instantiate the value_type to be able to access the key.
         // 1. emplace_back the object so it is constructed. 2. If the key is already there, pop it later in the loop.
         auto& key = get_key(m_values.emplace_back(std::forward<Args>(args)...));

--- a/test/meson.build
+++ b/test/meson.build
@@ -52,6 +52,7 @@ test_sources = [
     'unit/initializer_list.cpp',
     'unit/insert_or_assign.cpp',
     'unit/insert.cpp',
+    'unit/lazy_bucket_allocation.cpp',
     'unit/iterators_empty.cpp',
     'unit/iterators_erase.cpp',
     'unit/iterators_insert.cpp',

--- a/test/unit/lazy_bucket_allocation.cpp
+++ b/test/unit/lazy_bucket_allocation.cpp
@@ -1,0 +1,322 @@
+#include <ankerl/unordered_dense.h>
+
+#include <app/doctest.h>
+#include <app/id_allocator.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+// Issue #159: default construction used to allocate the bucket array, so a map declared in a scope
+// that might never use it still cost an allocation. It is now allocated by the first insert, which
+// means "no elements" and "no buckets" are the same state -- and every operation has to keep
+// working in it.
+namespace {
+
+using pair_t = std::pair<int, int>;
+
+template <typename Alloc>
+using map_of = ankerl::unordered_dense::map<int, int, ankerl::unordered_dense::hash<int>, std::equal_to<int>, Alloc>;
+
+template <typename Alloc>
+using segmented_map_of =
+    ankerl::unordered_dense::segmented_map<int, int, ankerl::unordered_dense::hash<int>, std::equal_to<int>, Alloc>;
+
+template <typename Alloc>
+using set_of = ankerl::unordered_dense::set<int, ankerl::unordered_dense::hash<int>, std::equal_to<int>, Alloc>;
+
+using counting_alloc = test::id_allocator<pair_t>;
+using counting_map = map_of<counting_alloc>;
+using counting_segmented_map = segmented_map_of<counting_alloc>;
+using counting_set = set_of<test::id_allocator<int>>;
+
+// A set whose emplace() goes through the single-argument transparent overload rather than the
+// variadic one -- a third insert entry point, with its own path to the buckets.
+struct transparent_hash {
+    using is_transparent = void;
+    using is_avalanching = void;
+
+    auto operator()(std::string_view sv) const noexcept -> std::uint64_t {
+        return ankerl::unordered_dense::hash<std::string_view>{}(sv);
+    }
+};
+
+using transparent_set =
+    ankerl::unordered_dense::set<std::string, transparent_hash, std::equal_to<>, test::id_allocator<std::string>>;
+
+// Every container here is built through the (bucket_count, allocator) constructor with a count of
+// zero, which is what a default construction resolves to.
+template <typename Map>
+auto tracked(test::alloc_counts& counts) -> Map {
+    return Map(0, typename Map::allocator_type(0, &counts));
+}
+
+// What a table costs before it has allocated anything of its own. Not zero everywhere: a table is
+// two containers, the values and the buckets, and MSVC's debug iterator support allocates a
+// _Container_proxy through the allocator for each one as it is constructed. So the floor is
+// measured rather than assumed -- two empty vectors' worth, whatever that is here.
+auto empty_table_cost() -> int {
+    auto counts = test::alloc_counts{};
+    {
+        auto values = std::vector<pair_t, test::id_allocator<pair_t>>(test::id_allocator<pair_t>(0, &counts));
+        auto buckets = std::vector<pair_t, test::id_allocator<pair_t>>(test::id_allocator<pair_t>(0, &counts));
+        static_cast<void>(values);
+        static_cast<void>(buckets);
+    }
+    return counts.allocations;
+}
+
+template <typename Map>
+void require_holds(Map const& map, int count) {
+    REQUIRE(map.size() == static_cast<std::size_t>(count));
+    for (int i = 0; i < count; ++i) {
+        REQUIRE(map.find(i) != map.end());
+    }
+}
+
+} // namespace
+
+TEST_CASE("default_construction_allocates_nothing") {
+    auto counts = test::alloc_counts{};
+
+    SUBCASE("map") {
+        auto map = tracked<counting_map>(counts);
+        REQUIRE(counts.allocations == empty_table_cost());
+        REQUIRE(map.bucket_count() == 0);
+        REQUIRE(map.size() == 0);
+        REQUIRE(map.empty());
+    }
+
+    SUBCASE("segmented map") {
+        auto map = tracked<counting_segmented_map>(counts);
+        REQUIRE(counts.allocations == empty_table_cost());
+        REQUIRE(map.bucket_count() == 0);
+    }
+
+    SUBCASE("set") {
+        auto set = tracked<counting_set>(counts);
+        REQUIRE(counts.allocations == empty_table_cost());
+        REQUIRE(set.bucket_count() == 0);
+    }
+}
+
+// Nothing may reach the bucket array while it is not there. The read paths get this by returning
+// early on empty(); this pins that they actually do.
+TEST_CASE("a_table_without_buckets_answers_every_query") {
+    auto map = ankerl::unordered_dense::map<int, int>();
+
+    REQUIRE(map.find(1) == map.end());
+    REQUIRE(map.count(1) == 0);
+    REQUIRE(!map.contains(1));
+    REQUIRE(map.erase(1) == 0);
+    REQUIRE(map.begin() == map.end());
+    REQUIRE(map.load_factor() == 0.0F);
+    REQUIRE(map.equal_range(1).first == map.end());
+    REQUIRE(std::as_const(map).find(1) == map.end());
+
+    auto other = ankerl::unordered_dense::map<int, int>();
+    map.swap(other);
+    REQUIRE(map.empty());
+
+    map.clear();
+    REQUIRE(map.bucket_count() == 0);
+
+    // extract() clears the buckets on the way out, with none to clear.
+    REQUIRE(std::move(map).extract().empty());
+}
+
+// One case per insert entry point, each starting from a container that has no buckets.
+TEST_CASE("the_first_insert_allocates_the_buckets") {
+    auto counts = test::alloc_counts{};
+
+    SUBCASE("operator[]") {
+        auto map = tracked<counting_map>(counts);
+        map[1] = 2;
+        REQUIRE(map.bucket_count() > 0);
+        REQUIRE(map[1] == 2);
+        REQUIRE(counts.allocations >= 2); // values and buckets
+    }
+
+    SUBCASE("try_emplace") {
+        auto map = tracked<counting_map>(counts);
+        REQUIRE(map.try_emplace(1, 2).second);
+        REQUIRE(map.find(1)->second == 2);
+    }
+
+    SUBCASE("insert") {
+        auto map = tracked<counting_map>(counts);
+        REQUIRE(map.insert(pair_t(1, 2)).second);
+        REQUIRE(map.find(1)->second == 2);
+    }
+
+    SUBCASE("emplace") {
+        auto map = tracked<counting_map>(counts);
+        REQUIRE(map.emplace(1, 2).second);
+        REQUIRE(map.find(1)->second == 2);
+    }
+
+    SUBCASE("insert_or_assign") {
+        auto map = tracked<counting_map>(counts);
+        REQUIRE(map.insert_or_assign(1, 2).second);
+        REQUIRE(map.find(1)->second == 2);
+    }
+
+    SUBCASE("range insert") {
+        auto source = std::vector<pair_t>{{1, 2}, {3, 4}};
+        auto map = tracked<counting_map>(counts);
+        map.insert(source.begin(), source.end());
+        REQUIRE(map.size() == 2);
+    }
+
+    SUBCASE("initializer list insert") {
+        auto map = tracked<counting_map>(counts);
+        map.insert({{1, 2}, {3, 4}});
+        REQUIRE(map.size() == 2);
+    }
+
+    SUBCASE("set emplace") {
+        auto set = tracked<counting_set>(counts);
+        REQUIRE(set.emplace(1).second);
+        REQUIRE(set.contains(1));
+    }
+
+    // The single-argument transparent overload, which probes the buckets before constructing
+    // anything at all.
+    SUBCASE("transparent set emplace") {
+        auto set = transparent_set(0, test::id_allocator<std::string>(0, &counts));
+        REQUIRE(counts.allocations == empty_table_cost());
+        REQUIRE(set.emplace(std::string_view("hello")).second);
+        REQUIRE(set.contains(std::string_view("hello")));
+    }
+
+    SUBCASE("replace") {
+        auto map = tracked<counting_map>(counts);
+        map.replace(counting_map::value_container_type{{1, 2}, {3, 4}});
+        REQUIRE(map.size() == 2);
+        REQUIRE(map.find(3)->second == 4);
+    }
+
+    SUBCASE("segmented map") {
+        auto map = tracked<counting_segmented_map>(counts);
+        map[1] = 2;
+        REQUIRE(map.bucket_count() > 0);
+        REQUIRE(map[1] == 2);
+    }
+}
+
+TEST_CASE("copying_an_empty_table_allocates_nothing") {
+    auto counts = test::alloc_counts{};
+    auto source = tracked<counting_map>(counts);
+
+    auto copy = source;
+    REQUIRE(counts.allocations == 2 * empty_table_cost()); // the source and the copy, nothing else
+    REQUIRE(copy.bucket_count() == 0);
+
+    auto assigned = tracked<counting_map>(counts);
+    assigned[1] = 2;
+    assigned = source;
+    REQUIRE(assigned.empty());
+    REQUIRE(assigned.bucket_count() == 0);
+
+    // ... and it is still a working map afterwards.
+    assigned[7] = 8;
+    REQUIRE(assigned.find(7)->second == 8);
+}
+
+// A moved-from table used to be handed a freshly allocated bucket array so that it stayed usable.
+// It is usable without one now, so the move does not allocate.
+TEST_CASE("a_moved_from_table_keeps_no_buckets") {
+    auto counts = test::alloc_counts{};
+
+    SUBCASE("move assignment") {
+        auto source = tracked<counting_map>(counts);
+        for (int i = 0; i < 100; ++i) {
+            source[i] = i;
+        }
+        auto target = tracked<counting_map>(counts);
+        auto const before = counts.allocations;
+
+        target = std::move(source);
+
+        REQUIRE(counts.allocations == before);
+        require_holds(target, 100);
+        REQUIRE(source.bucket_count() == 0); // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
+        REQUIRE(source.empty());             // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
+
+        source[1] = 2; // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
+        REQUIRE(source.find(1)->second == 2);
+    }
+
+    SUBCASE("move construction") {
+        auto source = tracked<counting_map>(counts);
+        source[1] = 2;
+        auto const before = counts.allocations;
+
+        auto target = std::move(source);
+
+        // Nothing beyond bringing the target's own two containers into existence.
+        REQUIRE(counts.allocations == before + empty_table_cost());
+        REQUIRE(target.find(1)->second == 2);
+        REQUIRE(source.bucket_count() == 0); // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
+    }
+}
+
+// An explicit request is still honoured up front -- laziness applies to the count that was not
+// asked for, not to the one that was.
+TEST_CASE("an_explicit_bucket_count_is_still_allocated_up_front") {
+    auto counts = test::alloc_counts{};
+
+    auto map = counting_map(150U, counting_alloc(0, &counts));
+    REQUIRE(map.bucket_count() == 256U);
+    REQUIRE(counts.allocations > 0);
+
+    auto reserved = tracked<counting_map>(counts);
+    reserved.reserve(1000);
+    REQUIRE(reserved.bucket_count() >= 1000);
+}
+
+// The lazily allocated table has to behave like the eagerly allocated one did, including on the
+// paths that grow and shrink it.
+TEST_CASE("a_lazily_allocated_table_grows_and_empties_like_any_other") {
+    auto map = ankerl::unordered_dense::map<int, int>();
+    auto const count = 1000;
+
+    for (int i = 0; i < count; ++i) {
+        map[i] = i;
+    }
+    require_holds(map, count);
+
+    for (int i = 0; i < count; ++i) {
+        REQUIRE(map.erase(i) == 1);
+    }
+    REQUIRE(map.empty());
+    REQUIRE(map.bucket_count() > 0); // erasing does not give the buckets back
+
+    // Refilling reuses them.
+    for (int i = 0; i < count; ++i) {
+        map[i] = i;
+    }
+    require_holds(map, count);
+}
+
+// Two tables in different states, swapped both ways round.
+TEST_CASE("swapping_an_unallocated_table_with_a_full_one") {
+    auto empty = ankerl::unordered_dense::map<int, int>();
+    auto full = ankerl::unordered_dense::map<int, int>();
+    for (int i = 0; i < 100; ++i) {
+        full[i] = i;
+    }
+
+    empty.swap(full);
+
+    require_holds(empty, 100);
+    REQUIRE(full.empty());
+    REQUIRE(full.bucket_count() == 0);
+
+    full[1] = 2;
+    REQUIRE(full.find(1)->second == 2);
+}

--- a/test/unit/pmr.cpp
+++ b/test/unit/pmr.cpp
@@ -225,7 +225,11 @@ TEST_CASE("pmr_move_same_mr") {
     REQUIRE(map1.find(3) != map1.end());
     show(mr1, "mr1");
 
-    REQUIRE(mr1.num_allocs() == 5); // 5 because of the initial allocation
+    // Two allocations per map, values and buckets, and nothing for the move: map1's buckets and
+    // values are handed over rather than copied, and map2 is left as a default constructed map,
+    // which no longer means "with a freshly allocated bucket array". That last one is what used to
+    // make this 5.
+    REQUIRE(mr1.num_allocs() == 4);
     REQUIRE(mr1.num_deallocs() == 2);
     REQUIRE(mr1.num_is_equals() == 0);
 }


### PR DESCRIPTION
Fixes #159. Default construction allocated the bucket array up front, so a map or set declared in a scope that might never use it still cost an allocation. It now costs nothing, and the array arrives with the first element.

### Why this was cheaper than the issue expected

The issue guessed this would need `if (m_buckets.empty())` checks sprinkled through the hot paths. It needs three, and none of them are on lookup.

The read paths already handle it: `do_find` and `do_erase_key` start with an `empty()` guard, and `erase`, `extract` and `replace_key` need an iterator into `m_values`, so they cannot be called in that state at all. That leaves the three insert entry points — `do_try_emplace`, the variadic `emplace`, and the single-argument transparent `emplace` for sets — as the only places that reach the buckets without first asking whether there are any. Those three call `allocate_buckets_if_none()`, before anything is inserted, so a failed allocation leaves the table untouched.

"No elements" and "no buckets" being the same state falls out of the existing code more than it is imposed on it: `bucket_count()` already reported `m_buckets.size()`, `load_factor()` already special-cased zero, `reserve()` and `replace()` already allocated when they found no buckets, and `clear()` already did nothing while the table was empty.

### Two allocations disappear, not one

Copying an empty table used to allocate buckets for the copy. And a move assignment used to hand the moved-from table a freshly allocated set so that it stayed usable — it is usable without them now, which takes an allocation, and a way to throw, out of an operation that is otherwise `noexcept` and needs neither. That is the same allocation the comment above `swap()` already complains about.

`clear_buckets()` grew an early return: `extract()` clears the buckets whether or not there are any, and `memset`'s pointer has to be valid even for a zero length.

### Cost

None I can measure. `bench_quick_overall_udm`, baseline and candidate binaries interleaved over four pairs:

| pair | baseline | lazy |
|---|---|---|
| 1 | 0.07665 | 0.07572 |
| 2 | 0.07727 | 0.07793 |
| 3 | 0.07795 | 0.07828 |
| 4 | 0.07717 | 0.07695 |

Each wins two, every delta under 1.2%, which is inside the run-to-run noise on this machine. The added branches are on the insert paths, predictably not taken, and the find path is untouched.

### Behaviour changes worth knowing about

- **`bucket_count()` on a default constructed table reports 0 rather than 4.** `test/unit/ctors.cpp` had already anticipated this in a comment ("could also be 0").
- **`test/unit/pmr.cpp`'s `pmr_move_same_mr` needed updating**, 5 allocations to 4. That assertion was counting exactly the moved-from bucket array this removes — its comment called it "the initial allocation".

### Tests

`test/unit/lazy_bucket_allocation.cpp` covers each insert entry point separately against an allocator that counts allocations, plus the queries that have to keep working with no buckets, copy and move, swap, and an explicit bucket count still being honoured up front.

Each of the three guards was removed in turn to confirm the tests catch it — all three segfault under address+undefined. The full suite passes under clang, gcc C++17 and ASan+UBSan, the fuzz corpora replay clean, and all four linters pass.

One guard is not covered by a failing-on-removal test: the early return in `clear_buckets()`. `data()` is null in that path (checked by printing it), but neither sanitizer objects to `memset(nullptr, 0, 0)`, so that one rests on the language rule rather than on a diagnostic. The comment says as much.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxhyeMXim7Pvb8SmYoEdBk)_