### PR TITLE
Test against libc++ on Linux too

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,20 @@ jobs:
             cpp_std: '23'
             apt: libboost-dev
 
+          # The only other standard library this project meets. Without this leg the sole libc++ in
+          # CI was macOS, so anything that differed between libc++ *versions* was invisible, and
+          # anything that differed between the two libraries could only be diagnosed by pushing to
+          # macOS and reading the log. Both have happened: a container proxy allocation on MSVC and
+          # an unconditional deallocate(nullptr, 0) on libc++ each cost a round trip to find.
+          # No libboost-dev here on purpose -- the runner's boost is built against libstdc++, and
+          # this leg exists to test one library at a time.
+          - name: Linux (clang, C++17, libc++)
+            id: linux-clang-cpp17-libcxx
+            os: ubuntu-latest
+            cxx: clang++
+            apt: libc++-dev libc++abi-dev
+            setup_args: -Dcpp_args=-stdlib=libc++ -Dcpp_link_args=-stdlib=libc++
+
           # A hash map that packs a bucket into 8 bytes and indexes with size_t is exactly the
           # design a different word size breaks, so 32 bit is real coverage, not a formality.
           # The runner images carry a 64 bit only toolchain, hence g++-multilib. -m32 used to be

--- a/test/unit/pmr.cpp
+++ b/test/unit/pmr.cpp
@@ -199,11 +199,22 @@ TEST_CASE("pmr_move_different_mr") {
 
     REQUIRE(mr1.num_allocs() == 3);
     REQUIRE(mr1.num_deallocs() == 1);
-    REQUIRE(mr1.num_is_equals() == 1);
 
     REQUIRE(mr2.num_allocs() == 2);
     REQUIRE(mr2.num_deallocs() == 0);
-    REQUIRE(mr2.num_is_equals() == 1);
+
+    // The total, not one comparison per resource -- that split is only how libstdc++ and Apple's
+    // libc++ happen to land. Two comparisons are made in all three standard libraries this is
+    // built against: table's own "same allocator?" check, and one inside std::vector's move
+    // assignment. pmr counts each against its left operand, and that is the half nothing pins
+    // down: table always asks mr1, while vector asks the source (mr2) under libstdc++ and the
+    // target (mr1) under libc++ 18. Same two comparisons, split 1/1 on one and 2/0 on the other.
+    //
+    // Kept as an equality rather than relaxed to "at least one", because the count is what would
+    // notice a redundant allocator comparison being added to the move path, and because all three
+    // libraries do agree on it. A fourth that does not will say so here, which is the useful
+    // outcome -- it is how the 2/0 split was found in the first place.
+    REQUIRE(mr1.num_is_equals() + mr2.num_is_equals() == 2);
 }
 
 TEST_CASE("pmr_move_same_mr") {


### PR DESCRIPTION
Closes #178.

Every Linux leg built against libstdc++, so the only libc++ in CI was macOS. Anything that differed between libc++ *versions* was invisible, and anything that differed between the two libraries could only be found by pushing and reading a macOS log. Both happened during #174 — MSVC's debug container proxies and libc++'s unconditional `deallocate(nullptr, 0)` — and each cost a CI round trip that a local reproduction then settled in minutes.

### The leg

clang with `-stdlib=libc++` at C++17. Deliberately no `libboost-dev`: the runner's boost is built against libstdc++, and this leg exists to test one standard library at a time.

### What it found, and what the fix is

It starts red on `pmr_move_different_mr`, which required exactly one allocator comparison against each of the two resources.

Two comparisons are made — `table`'s own "same allocator?" check, and one inside `std::vector`'s move assignment. `pmr` counts each against its **left operand**, and that is the half nothing pins down. Isolated with a standalone `std::vector<int, pmr::polymorphic_allocator<int>>` move assignment and a counting resource:

| | `table`'s check | `vector`'s move assign | mr1 / mr2 |
|---|---|---|---|
| libstdc++ | mr1 | mr2 (source) | 1 / 1 |
| Apple libc++ | mr1 | mr2 (source) | 1 / 1 |
| libc++ 18 | mr1 | mr1 (target) | **2 / 0** |

Same two comparisons, split differently. The assertion is now on the total.

Not relaxed to "at least one" — that would still pass if the map stopped comparing allocators altogether, since `vector`'s comparison would remain. All three standard libraries this is built against agree the total is two, so the equality holds everywhere it is checked today, and a fourth that disagrees will say so here. That is the useful outcome, and it is how the 2/0 split turned up in the first place.

The allocation and deallocation counts in that test are untouched; they were identical on every library throughout.

### Verification

Reproduced locally with the leg's exact meson invocation (`meson setup builddir --force-fallback-for=fmt -Dcpp_std=c++17 -Dcpp_args=-stdlib=libc++ -Dcpp_link_args=-stdlib=libc++`) before and after the test change: 457 cases, one failing, then none. Also green on clang/libstdc++, gcc C++17 and ASan+UBSan, and all four linters pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxhyeMXim7Pvb8SmYoEdBk)_