### PR TITLE
Copy the bucket array once instead of twice, and share the test fixtures

### DIFF
--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1190,13 +1190,23 @@ private:
             m_shifts = initial_shifts;
         } else {
             m_shifts = other.m_shifts;
-            allocate_buckets_from_shift();
             if constexpr (IsSegmented || !std::is_same_v<BucketContainer, default_container_t>) {
+                allocate_buckets_from_shift();
                 for (auto i = 0UL; i < bucket_count(); ++i) {
                     at(m_buckets, i) = at(other.m_buckets, i);
                 }
             } else {
-                std::memcpy(m_buckets.data(), other.m_buckets.data(), sizeof(Bucket) * bucket_count());
+                // One pass, not two. This used to grow the array with resize(), which value
+                // initialises every bucket it adds, and then memcpy over all of it -- so every byte
+                // of the bucket array was written twice, and for a large map the wasted half is a
+                // memset of megabytes. assign() copies straight into the new storage.
+                //
+                // assign() and not m_buckets = other.m_buckets, which would consult pocca: the
+                // allocator question is answered by the caller, and this is also reached from the
+                // move assignment's differing-allocator branch, where adopting other's would be
+                // exactly wrong.
+                m_buckets.assign(other.m_buckets.begin(), other.m_buckets.end());
+                describe_buckets(m_buckets.size());
             }
         }
     }
@@ -1313,6 +1323,12 @@ private:
         // indexing past the end of the array that is still there. This is the one function all six
         // bucket-allocating paths go through, so committing here rather than up front is what makes
         // a failed growth leave the old buckets intact and consistent instead of unusable.
+        describe_buckets(num_buckets);
+    }
+
+    // The two values derived from the bucket array's size. Only ever called once the array of that
+    // size exists; see the note above.
+    void describe_buckets(std::size_t num_buckets) {
         m_bucket_mask = static_cast<value_idx_type>(num_buckets - 1);
         if (num_buckets == max_bucket_count()) {
             // reached the maximum, make sure we can use each bucket

--- a/test/app/map_fixtures.h
+++ b/test/app/map_fixtures.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <app/doctest.h>
+
+#include <cstddef>
+#include <utility>
+
+// Fixtures shared by the allocator and exception-safety tests. They all build a map of i -> i and
+// then ask the same questions about it, and each of them used to carry its own copy of these --
+// four files, four subtly different answers to "does this map hold what it should".
+//
+// Nothing here is specific to allocators; test/app/id_allocator.h is where that lives.
+namespace test {
+
+// A map of count entries, i mapped to i. Built through the (bucket_count, allocator) constructor
+// with a count of zero, which is what a default construction resolves to, so the allocator stays
+// optional and the buckets are left to be allocated by the first insert.
+template <typename Map>
+auto filled(int count, typename Map::allocator_type alloc = {}) -> Map {
+    auto map = Map(0, alloc);
+    for (int i = 0; i < count; ++i) {
+        map.try_emplace(i, typename Map::mapped_type(i));
+    }
+    return map;
+}
+
+// ... and it holds exactly that, by lookup rather than by size alone.
+template <typename Map>
+void require_holds(Map const& map, int count) {
+    REQUIRE(map.size() == static_cast<std::size_t>(count));
+    for (int i = 0; i < count; ++i) {
+        auto it = map.find(i);
+        REQUIRE(it != map.end());
+        REQUIRE(it->second == i);
+    }
+}
+
+// Everything a table with no bucket array has to be able to answer. Two very different routes lead
+// to that state -- a table that was default constructed and never inserted into, and one that just
+// failed an assignment -- and it is the same state, so both are held to the same list. Keeping one
+// list is the point: the post-throw table is the harder of the two to get right, and it used to be
+// checked against the shorter of two lists.
+template <typename Map>
+void require_empty_table_answers(Map& map) {
+    REQUIRE(map.empty());
+    REQUIRE(map.size() == 0);
+    REQUIRE(map.bucket_count() == 0);
+    REQUIRE(map.load_factor() == 0.0F);
+
+    REQUIRE(map.begin() == map.end());
+    REQUIRE(map.find(1) == map.end());
+    REQUIRE(std::as_const(map).find(1) == map.end());
+    REQUIRE(map.count(1) == 0);
+    REQUIRE(!map.contains(1));
+    REQUIRE(map.equal_range(1).first == map.end());
+    REQUIRE(map.erase(1) == 0);
+
+    map.clear();
+    REQUIRE(map.bucket_count() == 0);
+
+    // ... and it is still a working map, which is the part that says the state is valid rather
+    // than merely quiet.
+    map.try_emplace(7, typename Map::mapped_type(7));
+    REQUIRE(map.size() == 1);
+    REQUIRE(map.find(7) != map.end());
+}
+
+} // namespace test

--- a/test/unit/assignment_exception_safety.cpp
+++ b/test/unit/assignment_exception_safety.cpp
@@ -1,6 +1,7 @@
 #include <ankerl/unordered_dense.h>
 
 #include <app/doctest.h>
+#include <app/map_fixtures.h>
 
 #include <cstddef>
 #include <stdexcept>
@@ -46,34 +47,6 @@ struct throws_on_copy {
 using map_t = ankerl::unordered_dense::map<int, throws_on_copy>;
 using segmented_map_t = ankerl::unordered_dense::segmented_map<int, throws_on_copy>;
 
-template <typename Map>
-auto filled(int count) -> Map {
-    auto map = Map();
-    for (int i = 0; i < count; ++i) {
-        map.try_emplace(i, throws_on_copy(i));
-    }
-    return map;
-}
-
-// Everything a table has to be able to answer, on a table that just failed an assignment.
-template <typename Map>
-void require_usable_and_empty(Map& map) {
-    REQUIRE(map.empty());
-    REQUIRE(map.size() == 0);
-    REQUIRE(map.begin() == map.end());
-    REQUIRE(map.find(1) == map.end());
-    REQUIRE(map.count(1) == 0);
-    REQUIRE(!map.contains(1));
-    REQUIRE(map.erase(1) == 0);
-
-    // ... and it still works as a map afterwards.
-    map.try_emplace(7, throws_on_copy(7));
-    REQUIRE(map.size() == 1);
-    auto it = map.find(7);
-    REQUIRE(it != map.end());
-    REQUIRE(it->second.m_value == 7);
-}
-
 struct countdown_guard {
     explicit countdown_guard(int n) {
         throws_on_copy::copies_until_throw = n;
@@ -89,15 +62,15 @@ struct countdown_guard {
 
 template <typename Map>
 void check_throwing_copy_assignment(int source_size, int target_size, int copies_until_throw) {
-    auto source = filled<Map>(source_size);
-    auto target = filled<Map>(target_size);
+    auto source = test::filled<Map>(source_size);
+    auto target = test::filled<Map>(target_size);
 
     {
         auto const guard = countdown_guard(copies_until_throw);
         REQUIRE_THROWS_AS(target = source, std::runtime_error);
     }
 
-    require_usable_and_empty(target);
+    test::require_empty_table_answers(target);
     // The source is untouched -- it was only ever read from.
     REQUIRE(source.size() == static_cast<std::size_t>(source_size));
 }

--- a/test/unit/lazy_bucket_allocation.cpp
+++ b/test/unit/lazy_bucket_allocation.cpp
@@ -2,6 +2,7 @@
 
 #include <app/doctest.h>
 #include <app/id_allocator.h>
+#include <app/map_fixtures.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -48,11 +49,12 @@ struct transparent_hash {
 using transparent_set =
     ankerl::unordered_dense::set<std::string, transparent_hash, std::equal_to<>, test::id_allocator<std::string>>;
 
-// Every container here is built through the (bucket_count, allocator) constructor with a count of
-// zero, which is what a default construction resolves to.
-template <typename Map>
-auto tracked(test::alloc_counts& counts) -> Map {
-    return Map(0, typename Map::allocator_type(0, &counts));
+// An empty container whose allocator reports back. Built through the (bucket_count, allocator)
+// constructor with a count of zero, which is what a default construction resolves to. Not
+// test::filled, which needs a mapped_type and so cannot serve the set cases below.
+template <typename Container>
+auto tracked(test::alloc_counts& counts) -> Container {
+    return Container(0, typename Container::allocator_type(0, &counts));
 }
 
 // What a table costs before it has allocated anything of its own. Not zero everywhere: a table is
@@ -68,14 +70,6 @@ auto empty_table_cost() -> int {
         static_cast<void>(buckets);
     }
     return counts.allocations;
-}
-
-template <typename Map>
-void require_holds(Map const& map, int count) {
-    REQUIRE(map.size() == static_cast<std::size_t>(count));
-    for (int i = 0; i < count; ++i) {
-        REQUIRE(map.find(i) != map.end());
-    }
 }
 
 } // namespace
@@ -105,28 +99,20 @@ TEST_CASE("default_construction_allocates_nothing") {
 }
 
 // Nothing may reach the bucket array while it is not there. The read paths get this by returning
-// early on empty(); this pins that they actually do.
+// early on empty(); this pins that they actually do. The list itself is shared with the test for a
+// table that just failed an assignment, which lands in the same state by a different route.
 TEST_CASE("a_table_without_buckets_answers_every_query") {
     auto map = ankerl::unordered_dense::map<int, int>();
+    test::require_empty_table_answers(map);
 
-    REQUIRE(map.find(1) == map.end());
-    REQUIRE(map.count(1) == 0);
-    REQUIRE(!map.contains(1));
-    REQUIRE(map.erase(1) == 0);
-    REQUIRE(map.begin() == map.end());
-    REQUIRE(map.load_factor() == 0.0F);
-    REQUIRE(map.equal_range(1).first == map.end());
-    REQUIRE(std::as_const(map).find(1) == map.end());
-
+    auto swapped = ankerl::unordered_dense::map<int, int>();
     auto other = ankerl::unordered_dense::map<int, int>();
-    map.swap(other);
-    REQUIRE(map.empty());
-
-    map.clear();
-    REQUIRE(map.bucket_count() == 0);
+    swapped.swap(other);
+    REQUIRE(swapped.empty());
 
     // extract() clears the buckets on the way out, with none to clear.
-    REQUIRE(std::move(map).extract().empty());
+    auto extracted = ankerl::unordered_dense::map<int, int>();
+    REQUIRE(std::move(extracted).extract().empty());
 }
 
 // One case per insert entry point, each starting from a container that has no buckets.
@@ -243,7 +229,7 @@ TEST_CASE("a_moved_from_table_keeps_no_buckets") {
         target = std::move(source);
 
         REQUIRE(counts.allocations == before);
-        require_holds(target, 100);
+        test::require_holds(target, 100);
         REQUIRE(source.bucket_count() == 0); // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
         REQUIRE(source.empty());             // NOLINT(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
 
@@ -288,7 +274,7 @@ TEST_CASE("a_lazily_allocated_table_grows_and_empties_like_any_other") {
     for (int i = 0; i < count; ++i) {
         map[i] = i;
     }
-    require_holds(map, count);
+    test::require_holds(map, count);
 
     for (int i = 0; i < count; ++i) {
         REQUIRE(map.erase(i) == 1);
@@ -300,7 +286,7 @@ TEST_CASE("a_lazily_allocated_table_grows_and_empties_like_any_other") {
     for (int i = 0; i < count; ++i) {
         map[i] = i;
     }
-    require_holds(map, count);
+    test::require_holds(map, count);
 }
 
 // Two tables in different states, swapped both ways round.
@@ -313,7 +299,7 @@ TEST_CASE("swapping_an_unallocated_table_with_a_full_one") {
 
     empty.swap(full);
 
-    require_holds(empty, 100);
+    test::require_holds(empty, 100);
     REQUIRE(full.empty());
     REQUIRE(full.bucket_count() == 0);
 

--- a/test/unit/table_allocators.cpp
+++ b/test/unit/table_allocators.cpp
@@ -2,6 +2,7 @@
 
 #include <app/doctest.h>
 #include <app/id_allocator.h>
+#include <app/map_fixtures.h>
 
 #include <cstddef>
 #include <functional>
@@ -38,30 +39,11 @@ using pocca = test::pocca_allocator<value_type>;
 using pocma = test::pocma_allocator<value_type>;
 using pocs = test::pocs_allocator<value_type>;
 
-template <typename Map>
-auto filled(typename Map::allocator_type alloc, int count) -> Map {
-    auto map = Map(0, alloc);
-    for (int i = 0; i < count; ++i) {
-        map[i] = i;
-    }
-    return map;
-}
-
 // Carries a map type into a generic lambda, which cannot take a type parameter of its own.
 template <typename T>
 struct tag_of {
     using type = T;
 };
-
-template <typename Map>
-void require_holds(Map const& map, int count) {
-    REQUIRE(map.size() == static_cast<std::size_t>(count));
-    for (int i = 0; i < count; ++i) {
-        auto it = map.find(i);
-        REQUIRE(it != map.end());
-        REQUIRE(it->second == i);
-    }
-}
 
 } // namespace
 
@@ -70,25 +52,25 @@ void require_holds(Map const& map, int count) {
 // silently kept that arena alive and kept allocating into it.
 TEST_CASE("table_copy_construction_asks_the_allocator") {
     SUBCASE("an allocator that declines is not inherited") {
-        auto source = filled<map_of<pmr_like>>(pmr_like(7), 20);
+        auto source = test::filled<map_of<pmr_like>>(20, pmr_like(7));
         auto copy = source;
         REQUIRE(copy.get_allocator().m_id == 0);
-        require_holds(copy, 20);
-        require_holds(source, 20);
+        test::require_holds(copy, 20);
+        test::require_holds(source, 20);
     }
 
     SUBCASE("an allocator that accepts is inherited") {
-        auto source = filled<map_of<inheriting>>(inheriting(7), 20);
+        auto source = test::filled<map_of<inheriting>>(20, inheriting(7));
         auto copy = source;
         REQUIRE(copy.get_allocator().m_id == 7);
-        require_holds(copy, 20);
+        test::require_holds(copy, 20);
     }
 
     SUBCASE("the segmented map answers the same way") {
-        auto source = filled<segmented_map_of<pmr_like>>(pmr_like(7), 20);
+        auto source = test::filled<segmented_map_of<pmr_like>>(20, pmr_like(7));
         auto copy = source;
         REQUIRE(copy.get_allocator().m_id == 0);
-        require_holds(copy, 20);
+        test::require_holds(copy, 20);
     }
 }
 
@@ -97,35 +79,35 @@ TEST_CASE("table_copy_construction_asks_the_allocator") {
 // landed in the default resource while the values went where the caller said.
 TEST_CASE("table_constructors_put_the_buckets_where_they_were_told") {
     SUBCASE("copy with an allocator") {
-        auto source = filled<map_of<inheriting>>(inheriting(1), 200);
+        auto source = test::filled<map_of<inheriting>>(200, inheriting(1));
         auto counts = test::alloc_counts{};
 
         auto copy = map_of<inheriting>(source, inheriting(9, &counts));
 
         REQUIRE(copy.get_allocator().m_id == 9);
-        require_holds(copy, 200);
+        test::require_holds(copy, 200);
         // Values and buckets, not just values.
         REQUIRE(counts.allocations >= 2);
     }
 
     SUBCASE("move with an allocator") {
-        auto source = filled<map_of<inheriting>>(inheriting(1), 200);
+        auto source = test::filled<map_of<inheriting>>(200, inheriting(1));
         auto counts = test::alloc_counts{};
 
         auto moved = map_of<inheriting>(std::move(source), inheriting(9, &counts));
 
-        require_holds(moved, 200);
+        test::require_holds(moved, 200);
         REQUIRE(counts.allocations >= 2);
     }
 
     SUBCASE("the segmented map answers the same way") {
-        auto source = filled<segmented_map_of<inheriting>>(inheriting(1), 200);
+        auto source = test::filled<segmented_map_of<inheriting>>(200, inheriting(1));
         auto counts = test::alloc_counts{};
 
         auto copy = segmented_map_of<inheriting>(source, inheriting(9, &counts));
 
         REQUIRE(copy.get_allocator().m_id == 9);
-        require_holds(copy, 200);
+        test::require_holds(copy, 200);
         REQUIRE(counts.allocations >= 2);
     }
 }
@@ -134,8 +116,8 @@ TEST_CASE("table_constructors_put_the_buckets_where_they_were_told") {
 TEST_CASE("table_gives_every_block_back_to_the_allocator_that_produced_it") {
     auto counts = test::alloc_counts{};
     {
-        auto map = filled<map_of<inheriting>>(inheriting(3, &counts), 200);
-        require_holds(map, 200);
+        auto map = test::filled<map_of<inheriting>>(200, inheriting(3, &counts));
+        test::require_holds(map, 200);
     }
     REQUIRE(counts.allocations > 0);
     REQUIRE(counts.deallocations == counts.allocations);
@@ -155,20 +137,20 @@ TEST_CASE("table_copy_assignment_takes_the_allocator_for_both_halves") {
     // holds nothing of its any more, so nothing the target does from here can reach it.
     auto check = [&](auto tag) {
         using map_type = typename decltype(tag)::type;
-        auto source = filled<map_type>(pocca(1, &source_counts), 200);
-        auto target = filled<map_type>(pocca(2, &target_counts), 50);
+        auto source = test::filled<map_type>(200, pocca(1, &source_counts));
+        auto target = test::filled<map_type>(50, pocca(2, &target_counts));
 
         target = source;
 
         REQUIRE(target.get_allocator().m_id == 1);
-        require_holds(target, 200);
+        test::require_holds(target, 200);
 
         // Growing the target reallocates both halves, and every byte of it has to come from
         // allocator 1 now. The buckets used to stay behind, so this went to allocator 2.
         auto const before = target_counts.allocations;
         target.reserve(20000);
         REQUIRE(target_counts.allocations == before);
-        require_holds(target, 200);
+        test::require_holds(target, 200);
     };
 
     SUBCASE("map") {
@@ -193,17 +175,17 @@ TEST_CASE("table_copy_assignment_takes_the_allocator_for_both_halves") {
 // allocator the result held the source's allocator and the caller's was dropped.
 TEST_CASE("extended_move_construction_uses_the_allocator_it_was_given") {
     SUBCASE("map") {
-        auto source = filled<map_of<pocma>>(pocma(1), 200);
+        auto source = test::filled<map_of<pocma>>(200, pocma(1));
         auto moved = map_of<pocma>(std::move(source), pocma(9));
         REQUIRE(moved.get_allocator().m_id == 9);
-        require_holds(moved, 200);
+        test::require_holds(moved, 200);
     }
 
     SUBCASE("segmented map") {
-        auto source = filled<segmented_map_of<pocma>>(pocma(1), 200);
+        auto source = test::filled<segmented_map_of<pocma>>(200, pocma(1));
         auto moved = segmented_map_of<pocma>(std::move(source), pocma(9));
         REQUIRE(moved.get_allocator().m_id == 9);
-        require_holds(moved, 200);
+        test::require_holds(moved, 200);
     }
 
     SUBCASE("segmented_vector on its own") {
@@ -243,41 +225,41 @@ TEST_CASE("extended_move_construction_uses_the_allocator_it_was_given") {
 // choices answered the same question differently for the same map.
 TEST_CASE("swap_exchanges_the_allocators_when_asked_to") {
     SUBCASE("map") {
-        auto a = filled<map_of<pocs>>(pocs(1), 100);
-        auto b = filled<map_of<pocs>>(pocs(2), 30);
+        auto a = test::filled<map_of<pocs>>(100, pocs(1));
+        auto b = test::filled<map_of<pocs>>(30, pocs(2));
 
         a.swap(b);
 
         REQUIRE(a.get_allocator().m_id == 2);
         REQUIRE(b.get_allocator().m_id == 1);
-        require_holds(a, 30);
-        require_holds(b, 100);
+        test::require_holds(a, 30);
+        test::require_holds(b, 100);
     }
 
     SUBCASE("segmented map") {
-        auto a = filled<segmented_map_of<pocs>>(pocs(1), 100);
-        auto b = filled<segmented_map_of<pocs>>(pocs(2), 30);
+        auto a = test::filled<segmented_map_of<pocs>>(100, pocs(1));
+        auto b = test::filled<segmented_map_of<pocs>>(30, pocs(2));
 
         a.swap(b);
 
         REQUIRE(a.get_allocator().m_id == 2);
         REQUIRE(b.get_allocator().m_id == 1);
-        require_holds(a, 30);
-        require_holds(b, 100);
+        test::require_holds(a, 30);
+        test::require_holds(b, 100);
     }
 
     // Equal allocators, so nothing propagates and nothing is reallocated either way.
     SUBCASE("swapping costs no allocation") {
         auto counts = test::alloc_counts{};
-        auto a = filled<segmented_map_of<inheriting>>(inheriting(1, &counts), 100);
-        auto b = filled<segmented_map_of<inheriting>>(inheriting(1, &counts), 30);
+        auto a = test::filled<segmented_map_of<inheriting>>(100, inheriting(1, &counts));
+        auto b = test::filled<segmented_map_of<inheriting>>(30, inheriting(1, &counts));
         auto const before = counts.allocations;
 
         a.swap(b);
 
         REQUIRE(counts.allocations == before);
-        require_holds(a, 30);
-        require_holds(b, 100);
+        test::require_holds(a, 30);
+        test::require_holds(b, 100);
     }
 }
 


### PR DESCRIPTION
Closes #179, both halves.

### 1 — `copy_buckets` wrote every byte of the bucket array twice

It grew the array with `resize()`, which value-initialises every bucket it adds, and then `memcpy`'d over all of it. For a large map the wasted half is a memset of megabytes. `assign()` copies straight into the new storage.

`assign()` and not `m_buckets = other.m_buckets`, which would consult POCCA: the allocator question is the caller's to answer, and `copy_buckets` is also reached from the move assignment's differing-allocator branch, where adopting `other`'s allocator would be exactly wrong. The mask and capacity that `allocate_buckets_from_shift` derives from the array's size move into a `describe_buckets()` helper so both paths can reach them without going through the growth step.

**Measured on `bench_copy`**, interleaved against main over three pairs, ns/op:

| pair | main | branch |
|---|---|---|
| 1 | 3.23 | **2.45** |
| 2 | 3.12 | **2.63** |
| 3 | 3.20 | **2.44** |

16–24%, winning every pair. The segmented and deque legs of the same benchmark do not move, which is the shape to expect — only the flat branch changed. `bench_quick_overall_udm` is unchanged too, within half a percent over three pairs; the copy path is not the find path.

The review that suggested this measured 25–40% in its own scratch harness. This is the repo's own benchmark and the smaller number is the one to believe.

### 2 — the duplicated test fixtures

The files that each carried their own `filled()` and `require_holds()` now share `test/app/map_fixtures.h`. `segmented_vector_allocators.cpp` keeps its own: those are for a vector and only look similar.

The shared header also carries the list of what a table with no bucket array has to answer. Two routes reach that state — default-constructed and never inserted into, or an assignment that threw — and it is the same state, but the two were checked against different lists, with the *harder* of the two getting the shorter one. The post-throw table now also gets `bucket_count()`, `load_factor()`, `equal_range()` and the const `find()`, and passes them.

### Verification

Green on clang, gcc C++17, ASan+UBSan and libc++ (457 cases each); fuzz corpora replay clean; all four linters pass.

Reverting the copy to drop one bucket takes down eight test cases including the fuzz replay, so the change is covered rather than merely passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxhyeMXim7Pvb8SmYoEdBk)_