### PR TITLE
Build the new bucket array before releasing the old one

### DIFF
--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -1189,9 +1189,8 @@ private:
             // first insert allocate. Copying an empty table therefore allocates nothing either.
             m_shifts = initial_shifts;
         } else {
-            m_shifts = other.m_shifts;
             if constexpr (IsSegmented || !std::is_same_v<BucketContainer, default_container_t>) {
-                allocate_buckets_from_shift();
+                allocate_buckets_from_shift(other.m_shifts);
                 for (auto i = 0UL; i < bucket_count(); ++i) {
                     at(m_buckets, i) = at(other.m_buckets, i);
                 }
@@ -1206,6 +1205,7 @@ private:
                 // move assignment's differing-allocator branch, where adopting other's would be
                 // exactly wrong.
                 m_buckets.assign(other.m_buckets.begin(), other.m_buckets.end());
+                m_shifts = other.m_shifts;
                 describe_buckets(m_buckets.size());
             }
         }
@@ -1306,23 +1306,47 @@ private:
         m_bucket_mask = 0;
     }
 
-    void allocate_buckets_from_shift() {
-        auto num_buckets = calc_num_buckets(m_shifts);
+    // Takes the shift rather than reading m_shifts, so that nothing describing the bucket array is
+    // written until an array of that size exists. Callers used to assign m_shifts and then
+    // allocate, which left a gap for a failed allocation to stop in.
+    void allocate_buckets_from_shift(std::uint8_t shifts) {
+        auto num_buckets = calc_num_buckets(shifts);
         if constexpr (IsSegmented || !std::is_same_v<BucketContainer, default_container_t>) {
-            if constexpr (has_reserve<bucket_container_type>) {
-                m_buckets.reserve(num_buckets);
-            }
-            for (std::size_t i = m_buckets.size(); i < num_buckets; ++i) {
-                m_buckets.emplace_back();
+            if (num_buckets < m_buckets.size()) {
+                // Shrinking, which rehash does. This used to work because the caller emptied the
+                // array first and the loop below then grew it from nothing; without that it would
+                // keep the larger size. Shrinking rather than emptying is what keeps the array and
+                // the mask agreeing at every point: it hands memory back instead of asking for it,
+                // so unlike a clear-then-regrow it has no failure to stop in.
+                m_buckets.resize(num_buckets);
+            } else {
+                if constexpr (has_reserve<bucket_container_type>) {
+                    m_buckets.reserve(num_buckets);
+                }
+                // Growing in place leaves the old buckets where they are, so a failure part way
+                // through leaves an array that is merely larger than the mask below describes,
+                // which nothing reads.
+                for (std::size_t i = m_buckets.size(); i < num_buckets; ++i) {
+                    m_buckets.emplace_back();
+                }
             }
         } else {
-            m_buckets.resize(num_buckets);
+            // Built beside the old array rather than over it, so that a failure here leaves the
+            // table exactly as it was. Callers used to give the old array back first, which made
+            // this the only allocation alive -- and made a failure leave them holding values with
+            // no buckets to find them by, which is not a state anything can recover from without
+            // allocating again.
+            auto fresh = bucket_container_type(m_buckets.get_allocator());
+            fresh.resize(num_buckets);
+            m_buckets = std::move(fresh);
         }
-        // Only now that the array exists, and not before the growth above: these two describe it,
-        // and a mask published ahead of the allocation that failed would have left every probe
-        // indexing past the end of the array that is still there. This is the one function all six
-        // bucket-allocating paths go through, so committing here rather than up front is what makes
-        // a failed growth leave the old buckets intact and consistent instead of unusable.
+        // All three commit here, together, and only once the array they describe exists. They have
+        // to move as one: do_find indexes its first probe with hash >> m_shifts and does not mask,
+        // so a shift that has run ahead of the array reads past the end of it, and a mask published
+        // ahead of an allocation that then failed does the same. This is the one function every
+        // bucket-allocating path goes through, which is what makes a failed growth leave the old
+        // buckets intact and consistent rather than unusable.
+        m_shifts = shifts;
         describe_buckets(num_buckets);
     }
 
@@ -1347,7 +1371,7 @@ private:
     void allocate_buckets_if_none() {
         if (ANKERL_UNORDERED_DENSE_UNLIKELY(0 == bucket_count()))
             ANKERL_UNORDERED_DENSE_UNLIKELY_ATTR {
-                allocate_buckets_from_shift();
+                allocate_buckets_from_shift(m_shifts);
                 clear_buckets();
             }
     }
@@ -1387,11 +1411,22 @@ private:
             m_values.pop_back();
             on_error_bucket_overflow();
         }
-        --m_shifts;
-        if constexpr (!IsSegmented && std::is_same_v<BucketContainer, default_container_t>) {
-            deallocate_buckets();
+        // Both callers have already appended the new element to m_values, which is why the branch
+        // above takes it back out before reporting the overflow. A bucket array that cannot be
+        // grown is the same situation: the element is in m_values with no bucket pointing at it,
+        // and never will have one, so size() would count an element that find() cannot reach.
+        // Taking it back out is what makes a failed insert have no effect, which is what the
+        // unordered containers promise for inserting a single element.
+        if constexpr (ANKERL_UNORDERED_DENSE_HAS_EXCEPTIONS()) {
+            try {
+                allocate_buckets_from_shift(static_cast<std::uint8_t>(m_shifts - 1));
+            } catch (...) {
+                m_values.pop_back();
+                throw;
+            }
+        } else {
+            allocate_buckets_from_shift(static_cast<std::uint8_t>(m_shifts - 1));
         }
-        allocate_buckets_from_shift();
         clear_and_fill_buckets_from_values();
     }
 
@@ -1870,9 +1905,7 @@ public:
             }
         auto shifts = calc_shifts_for_size(container.size());
         if (0 == bucket_count() || shifts < m_shifts || container.get_allocator() != m_values.get_allocator()) {
-            m_shifts = shifts;
-            deallocate_buckets();
-            allocate_buckets_from_shift();
+            allocate_buckets_from_shift(shifts);
         }
         clear_buckets();
 
@@ -2380,10 +2413,8 @@ public:
         count = (std::min)(count, max_size());
         auto shifts = calc_shifts_for_size((std::max)(count, size()));
         if (shifts != m_shifts) {
-            m_shifts = shifts;
-            deallocate_buckets();
+            allocate_buckets_from_shift(shifts);
             m_values.shrink_to_fit();
-            allocate_buckets_from_shift();
             clear_and_fill_buckets_from_values();
         }
     }
@@ -2396,9 +2427,7 @@ public:
         }
         auto shifts = calc_shifts_for_size((std::max)(capa, size()));
         if (0 == bucket_count() || shifts < m_shifts) {
-            m_shifts = shifts;
-            deallocate_buckets();
-            allocate_buckets_from_shift();
+            allocate_buckets_from_shift(shifts);
             clear_and_fill_buckets_from_values();
         }
     }

--- a/include/ankerl/unordered_dense.h
+++ b/include/ankerl/unordered_dense.h
@@ -739,6 +739,13 @@ private:
     // slow path: need to allocate a new segment every once in a while
     void increase_capacity() {
         auto ba = Allocator(m_blocks.get_allocator());
+
+        // Room for the pointer first. push_back is the other thing here that can throw -- it
+        // reallocates -- and it used to do so with the block already allocated and owned by
+        // nobody, which leaked it. Reserving first means the only allocation still outstanding
+        // when something fails is one that has not happened yet, and the push_back below cannot
+        // fail because the capacity is already there.
+        m_blocks.reserve(m_blocks.size() + 1);
         pointer block = std::allocator_traits<Allocator>::allocate(ba, num_elements_in_block);
         m_blocks.push_back(block);
     }

--- a/test/app/bombing_allocator.h
+++ b/test/app/bombing_allocator.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <new>
+
+// An allocator that throws on the nth allocation, for testing what a container does when it runs
+// out of memory part way through an operation. The countdown is global rather than per instance,
+// because the point is usually to fail one specific allocation inside a call, and a container's
+// allocator has usually been copied and rebound several times by the time it gets there.
+namespace test {
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+inline int g_allocations_until_throw = -1;
+
+// Arms the countdown for as long as it is in scope. -1, the resting state, never throws.
+struct bomb_after {
+    explicit bomb_after(int n) {
+        g_allocations_until_throw = n;
+    }
+    bomb_after(bomb_after const&) = delete;
+    bomb_after(bomb_after&&) = delete;
+    auto operator=(bomb_after const&) -> bomb_after& = delete;
+    auto operator=(bomb_after&&) -> bomb_after& = delete;
+    ~bomb_after() {
+        g_allocations_until_throw = -1;
+    }
+};
+
+template <typename T>
+struct bombing_allocator {
+    using value_type = T;
+
+    bombing_allocator() = default;
+
+    template <typename U>
+    // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+    bombing_allocator(bombing_allocator<U> const& /*unused*/) noexcept {}
+
+    auto allocate(std::size_t n) -> T* {
+        if (g_allocations_until_throw >= 0 && 0 == g_allocations_until_throw--) {
+            throw std::bad_alloc{};
+        }
+        return std::allocator<T>{}.allocate(n);
+    }
+
+    void deallocate(T* p, std::size_t n) {
+        std::allocator<T>{}.deallocate(p, n);
+    }
+
+    friend auto operator==(bombing_allocator /*unused*/, bombing_allocator /*unused*/) noexcept -> bool {
+        return true;
+    }
+
+    friend auto operator!=(bombing_allocator /*unused*/, bombing_allocator /*unused*/) noexcept -> bool {
+        return false;
+    }
+};
+
+} // namespace test

--- a/test/app/bombing_allocator.h
+++ b/test/app/bombing_allocator.h
@@ -8,6 +8,21 @@
 // out of memory part way through an operation. The countdown is global rather than per instance,
 // because the point is usually to fail one specific allocation inside a call, and a container's
 // allocator has usually been copied and rebound several times by the time it gets there.
+//
+// Usable only where a container construction does not allocate. MSVC's debug iterators allocate a
+// _Container_proxy through the allocator every time a container is constructed, and the standard
+// declares std::vector's allocator-only constructor noexcept -- so a throwing allocator terminates
+// there rather than propagating, whatever the container being tested does about it. That rules the
+// whole technique out under _ITERATOR_DEBUG_LEVEL, which is what ANKERL_TEST_CAN_BOMB_ALLOCATIONS
+// below reports.
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#if defined(_ITERATOR_DEBUG_LEVEL) && _ITERATOR_DEBUG_LEVEL != 0
+#    define ANKERL_TEST_CAN_BOMB_ALLOCATIONS() 0 // NOLINT(cppcoreguidelines-macro-usage)
+#else
+#    define ANKERL_TEST_CAN_BOMB_ALLOCATIONS() 1 // NOLINT(cppcoreguidelines-macro-usage)
+#endif
+
 namespace test {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/test/meson.build
+++ b/test/meson.build
@@ -45,6 +45,7 @@ test_sources = [
     'unit/fuzz_insert_erase.cpp',
     'unit/fuzz_replace_map.cpp',
     'unit/fuzz_string.cpp',
+    'unit/growth_exception_safety.cpp',
     'unit/hash_char_types.cpp',
     'unit/hash_smart_ptr.cpp',
     'unit/hash_string_view.cpp',

--- a/test/unit/growth_exception_safety.cpp
+++ b/test/unit/growth_exception_safety.cpp
@@ -52,19 +52,25 @@ void require_consistent(Map const& map, int searched_up_to) {
     REQUIRE(iterated == map.size());
 }
 
-// Runs op with every allocation budget up to a bound, and holds the table to the same standard
-// after each failure. Which allocation inside op is the bucket one is not worth guessing -- and it
-// moves as the code changes -- so every one of them gets its turn.
+// Runs op with a growing allocation budget and holds the table to the same standard after each
+// failure. Which allocation inside op is the bucket one is not worth guessing -- it moves as the
+// code changes, and how many allocations precede it differs by standard library, since MSVC's
+// debug iterators take one through the allocator for every container that gets constructed. So
+// rather than a fixed number of budgets, this walks upwards until the budget is large enough for
+// op to run to completion, which is the point at which every allocation it makes has had its turn
+// at failing. The bound is only a runaway guard.
 template <typename Map, typename Op>
 void require_survives_every_allocation_failure(int start_size, int searched_up_to, Op op) {
     auto failures = 0;
-    for (int budget = 0; budget < 12; ++budget) {
+    auto completed = false;
+    for (int budget = 0; budget < 1000 && !completed; ++budget) {
         auto map = filled<Map>(start_size);
         auto const before_size = map.size();
 
         try {
             auto const bomb = test::bomb_after(budget);
             op(map);
+            completed = true;
         } catch (std::bad_alloc const&) {
             ++failures;
         }
@@ -73,8 +79,10 @@ void require_survives_every_allocation_failure(int start_size, int searched_up_t
         // Nothing is ever lost: the table either did the whole thing or none of it.
         REQUIRE(map.size() >= before_size);
     }
-    // If nothing ever threw the test would be vacuous.
+    // Both halves matter: without a failure the test is vacuous, and without a completion it never
+    // reached the end of op and the later allocations went untested.
     REQUIRE(failures > 0);
+    REQUIRE(completed);
 }
 
 template <typename Alloc>

--- a/test/unit/growth_exception_safety.cpp
+++ b/test/unit/growth_exception_safety.cpp
@@ -59,6 +59,7 @@ void require_consistent(Map const& map, int searched_up_to) {
 // rather than a fixed number of budgets, this walks upwards until the budget is large enough for
 // op to run to completion, which is the point at which every allocation it makes has had its turn
 // at failing. The bound is only a runaway guard.
+#if ANKERL_TEST_CAN_BOMB_ALLOCATIONS()
 template <typename Map, typename Op>
 void require_survives_every_allocation_failure(int start_size, int searched_up_to, Op op) {
     auto failures = 0;
@@ -84,6 +85,7 @@ void require_survives_every_allocation_failure(int start_size, int searched_up_t
     REQUIRE(failures > 0);
     REQUIRE(completed);
 }
+#endif
 
 template <typename Alloc>
 using map_of = ankerl::unordered_dense::map<int, int, ankerl::unordered_dense::hash<int>, std::equal_to<int>, Alloc>;
@@ -96,6 +98,10 @@ using bombing_map = map_of<test::bombing_allocator<pair_t>>;
 using bombing_segmented_map = segmented_map_of<test::bombing_allocator<pair_t>>;
 
 } // namespace
+
+// Every case below makes an allocation fail on purpose; see ANKERL_TEST_CAN_BOMB_ALLOCATIONS. The
+// legs that cannot run them are the MSVC ones, and MinGW covers Windows here.
+#if ANKERL_TEST_CAN_BOMB_ALLOCATIONS()
 
 TEST_CASE("reserve_that_cannot_allocate_leaves_the_table_alone") {
     require_survives_every_allocation_failure<bombing_map>(100, 200, [](bombing_map& map) {
@@ -141,6 +147,8 @@ TEST_CASE("the_segmented_map_survives_the_same_failures") {
         map.reserve(100000);
     });
 }
+
+#endif
 
 // Shrinking is the other direction, and it is not in the harness above because it cannot fail:
 // it hands storage back rather than asking for it, so there is no allocation to bomb. It needs its

--- a/test/unit/growth_exception_safety.cpp
+++ b/test/unit/growth_exception_safety.cpp
@@ -1,0 +1,153 @@
+#include <ankerl/unordered_dense.h>
+
+#include <app/bombing_allocator.h>
+#include <app/doctest.h>
+
+#include <cstddef>
+#include <functional>
+#include <new>
+#include <utility>
+
+// Issue #182. reserve, rehash, replace and growing on insert all need a bigger bucket array, and
+// all of them used to give the old one back before asking for the new one. When the ask failed the
+// table was left holding values with no buckets to find them by, which no operation is prepared
+// for: do_find returns early only while m_values is empty, so a non-empty table with no buckets
+// probed a container of length zero and crashed.
+//
+// Each of them now builds the new array beside the old one, so a failure leaves the table exactly
+// as it was.
+namespace {
+
+using pair_t = std::pair<int, int>;
+
+template <typename Map>
+auto filled(int count) -> Map {
+    auto map = Map();
+    for (int i = 0; i < count; ++i) {
+        map[i] = i;
+    }
+    return map;
+}
+
+// The table has to agree with itself: everything size() counts has to be reachable, and everything
+// reachable has to have the value it was given.
+template <typename Map>
+void require_consistent(Map const& map, int searched_up_to) {
+    auto found = 0;
+    for (int i = 0; i < searched_up_to; ++i) {
+        auto it = map.find(i);
+        if (it != map.end()) {
+            REQUIRE(it->second == i);
+            ++found;
+        }
+    }
+    REQUIRE(map.size() == static_cast<std::size_t>(found));
+
+    // Iteration has to see exactly the same elements.
+    auto iterated = std::size_t{0};
+    for (auto const& entry : map) {
+        REQUIRE(map.find(entry.first) != map.end());
+        ++iterated;
+    }
+    REQUIRE(iterated == map.size());
+}
+
+// Runs op with every allocation budget up to a bound, and holds the table to the same standard
+// after each failure. Which allocation inside op is the bucket one is not worth guessing -- and it
+// moves as the code changes -- so every one of them gets its turn.
+template <typename Map, typename Op>
+void require_survives_every_allocation_failure(int start_size, int searched_up_to, Op op) {
+    auto failures = 0;
+    for (int budget = 0; budget < 12; ++budget) {
+        auto map = filled<Map>(start_size);
+        auto const before_size = map.size();
+
+        try {
+            auto const bomb = test::bomb_after(budget);
+            op(map);
+        } catch (std::bad_alloc const&) {
+            ++failures;
+        }
+
+        require_consistent(map, searched_up_to);
+        // Nothing is ever lost: the table either did the whole thing or none of it.
+        REQUIRE(map.size() >= before_size);
+    }
+    // If nothing ever threw the test would be vacuous.
+    REQUIRE(failures > 0);
+}
+
+template <typename Alloc>
+using map_of = ankerl::unordered_dense::map<int, int, ankerl::unordered_dense::hash<int>, std::equal_to<int>, Alloc>;
+
+template <typename Alloc>
+using segmented_map_of =
+    ankerl::unordered_dense::segmented_map<int, int, ankerl::unordered_dense::hash<int>, std::equal_to<int>, Alloc>;
+
+using bombing_map = map_of<test::bombing_allocator<pair_t>>;
+using bombing_segmented_map = segmented_map_of<test::bombing_allocator<pair_t>>;
+
+} // namespace
+
+TEST_CASE("reserve_that_cannot_allocate_leaves_the_table_alone") {
+    require_survives_every_allocation_failure<bombing_map>(100, 200, [](bombing_map& map) {
+        map.reserve(100000);
+    });
+}
+
+TEST_CASE("rehash_that_cannot_allocate_leaves_the_table_alone") {
+    require_survives_every_allocation_failure<bombing_map>(100, 200, [](bombing_map& map) {
+        map.rehash(100000);
+    });
+}
+
+TEST_CASE("replace_that_cannot_allocate_leaves_the_table_alone") {
+    require_survives_every_allocation_failure<bombing_map>(100, 6000, [](bombing_map& map) {
+        // Built with the countdown already running, so whichever allocation fails first is the one
+        // under test -- including the ones inside replace() itself.
+        auto container = bombing_map::value_container_type{};
+        for (int i = 0; i < 5000; ++i) {
+            container.emplace_back(i, i);
+        }
+        map.replace(std::move(container));
+    });
+}
+
+// The one reachable without asking for anything: an ordinary insert loop, growing.
+TEST_CASE("growing_on_insert_that_cannot_allocate_leaves_the_table_alone") {
+    require_survives_every_allocation_failure<bombing_map>(100, 4000, [](bombing_map& map) {
+        for (int i = 100; i < 3000; ++i) {
+            map[i] = i;
+        }
+    });
+}
+
+TEST_CASE("the_segmented_map_survives_the_same_failures") {
+    require_survives_every_allocation_failure<bombing_segmented_map>(100, 4000, [](bombing_segmented_map& map) {
+        for (int i = 100; i < 3000; ++i) {
+            map[i] = i;
+        }
+    });
+
+    require_survives_every_allocation_failure<bombing_segmented_map>(100, 200, [](bombing_segmented_map& map) {
+        map.reserve(100000);
+    });
+}
+
+// Shrinking is the other direction, and it is not in the harness above because it cannot fail:
+// it hands storage back rather than asking for it, so there is no allocation to bomb. It needs its
+// own case anyway, because the container that grows in place -- the segmented and custom ones --
+// has to be told to shrink now that the caller no longer empties it first. Getting that wrong
+// leaves the array at its old size, which is what rehash's own test caught.
+TEST_CASE_MAP("shrinking_the_bucket_array_keeps_it_consistent", int, int) {
+    auto map = filled<map_t>(2000);
+
+    map.rehash(100000);
+    auto const grown = map.bucket_count();
+    REQUIRE(grown >= 100000);
+
+    map.rehash(0);
+    REQUIRE(map.bucket_count() < grown);
+    REQUIRE(map.bucket_count() >= map.size());
+    require_consistent(map, 3000);
+}


### PR DESCRIPTION
Closes #182.

`reserve`, `rehash`, `replace` and growing on insert all need a bigger bucket array, and all of them gave the old one back before asking for the new one. When the ask failed, the table was left holding values with no buckets to find them by — and `do_find` returns early only while `m_values` is empty, so the next lookup probed a container of length zero and crashed.

### The choice in the issue turned out not to be a choice

I put it as: recover to empty (loses the caller's data) versus allocate before releasing (holds both arrays at once, doubling peak bucket memory during every growth). The second is **free**, which decides it.

Peak memory over an insert of ten million elements, `allocated_memory_std_vector`:

| | peak |
|---|---|
| main | 512.0 MiB |
| this branch | 512.0 MiB |

Identical to the byte. The peak is a reallocation of the *values* vector; the bucket events this change makes larger top out at 320 MiB, well underneath it. The two allocation timelines do differ at 96 recorded events, so that is the change being measured and not a change that failed to reach the binary.

So all four keep the caller's data, and a failure leaves the table exactly as it was.

### Two things had to move

**`allocate_buckets_from_shift` takes the shift** instead of reading `m_shifts`, and commits the shift, the mask and the capacity together once the array exists. `do_find` indexes its first probe with `hash >> m_shifts` and does **not** mask, so a shift assigned before a failed allocation reads past the end of the array that is still there. That was a second, narrower version of the same bug.

**The segmented and custom containers now shrink when asked to.** They grow in place, and relied on the caller emptying them first — so removing that left `rehash` keeping its old bucket count. `rehash`'s own test caught it, which is the nicest kind of failure to get.

### `increase_size` needed one more thing

Its callers append to `m_values` before calling it, which is why it already pops that element back off before reporting a bucket overflow. A failed allocation is the same situation, so it now does the same. Without it the table survived but `size()` counted 103 elements where only 102 could be found — a failed single-element insert now has no effect, which is what the unordered containers promise.

### Verification

- `test/unit/growth_exception_safety.cpp` runs each operation against **every** allocation budget in turn rather than guessing which allocation is the bucket one, and after each failure requires that `size()` matches what can be found and what iteration yields.
- Each of the three fixes reverted individually takes its own test down.
- 465 cases green on clang, gcc C++17, ASan+UBSan and libc++; fuzz corpora replay clean; all four linters pass.
- `bench_quick_overall_udm` interleaved over four pairs: branch wins two, loses two, everything inside 2%. None of this is on the lookup path.

### Note for custom `BucketContainer`s

The shrink path calls `resize()` on the bucket container. It previously called `clear()` and `shrink_to_fit()` there, so the requirement moved rather than grew; `std::deque` and `segmented_vector`, the two exercised in the tests, both have it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxhyeMXim7Pvb8SmYoEdBk)_