### PR TITLE
Refresh and regroup the Real World Usage list

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Additionally, there are `ankerl::unordered_dense::segmented_map` and `ankerl::un
   - [6.7. Networking, media and security](#67-networking-media-and-security)
   - [6.8. Finance and blockchain](#68-finance-and-blockchain)
   - [6.9. Tools, libraries and machine learning](#69-tools-libraries-and-machine-learning)
-- [7. Ports](#7-ports)
+  - [6.10. Ports](#610-ports)
 
 ## 1. Overview
 
@@ -467,7 +467,7 @@ Open source projects that use this map, grouped by what they do. The list was fi
 * [STP](https://github.com/stp/stp) - Simple Theorem Prover, an efficient SMT solver for bitvectors.
 * [Tulip](https://github.com/Tulip-Dev/tulip) - Large graphs analysis, drawing and visualization framework.
 
-## 7. Ports
+### 6.10. Ports
 
 Reimplementations of this design in other languages. They are not maintained here, and are listed because people have found them useful.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Additionally, there are `ankerl::unordered_dense::segmented_map` and `ankerl::un
   - [5.2. Lookups](#52-lookups)
   - [5.3. Removals](#53-removals)
 - [6. Real World Usage](#6-real-world-usage)
+- [7. Ports](#7-ports)
 
 ## 1. Overview
 
@@ -359,7 +360,7 @@ Since all data is stored in a vector, removals are a bit more complicated:
 
 ## 6. Real World Usage
 
-On 2023-09-10 I did a quick search on GitHub to see if this map is used in any popular open source projects. Here are some of the projects I found. Please send me a note if you want to be on that list!
+On 2023-09-10 I did a quick search on GitHub to see if this map is used in any popular open source projects. Here are some of the projects I found, plus the ones whose authors have written in since. Please send me a note if you want to be on that list!
 
 * [PrusaSlicer](https://github.com/prusa3d/PrusaSlicer) -  G-code generator for 3D printers (RepRap, Makerbot, Ultimaker etc.) 
 * [Kismet](https://github.com/kismetwireless/kismet): Wi-Fi, Bluetooth, RF, and more. Kismet is a sniffer, WIDS, and wardriving tool for Wi-Fi, Bluetooth, Zigbee, RF, and more, which runs on Linux and macOS
@@ -376,3 +377,10 @@ On 2023-09-10 I did a quick search on GitHub to see if this map is used in any p
 * [Operon](https://github.com/heal-research/operon) - A modern C++ framework for symbolic regression that uses genetic programming to explore a hypothesis space of possible mathematical expressions in order to find the best-fitting model for a given regression target.
 * [MashMap](https://github.com/marbl/MashMap) - A fast approximate aligner for long DNA sequences
 * [minigpt4.cpp](https://github.com/Maknee/minigpt4.cpp) - Port of MiniGPT4 in C++ (4bit, 5bit, 6bit, 8bit, 16bit CPU inference with GGML)
+* [CoMaps](https://codeberg.org/comaps/comaps) - Privacy-focused offline maps and navigation for Android and iOS, based on OpenStreetMap data.
+
+## 7. Ports
+
+Reimplementations of this design in other languages. They are not maintained here, and are listed because people have found them useful.
+
+* [HashMapC99](https://github.com/benanil/HashMapC99) - A cache-efficient, densely stored hash map in C99, by Anılcan Gülkaya. Useful where a C++17 header is not an option, such as embedded targets, and for shorter compile times and smaller binaries.

--- a/README.md
+++ b/README.md
@@ -378,6 +378,8 @@ On 2023-09-10 I did a quick search on GitHub to see if this map is used in any p
 * [MashMap](https://github.com/marbl/MashMap) - A fast approximate aligner for long DNA sequences
 * [minigpt4.cpp](https://github.com/Maknee/minigpt4.cpp) - Port of MiniGPT4 in C++ (4bit, 5bit, 6bit, 8bit, 16bit CPU inference with GGML)
 * [CoMaps](https://codeberg.org/comaps/comaps) - Privacy-focused offline maps and navigation for Android and iOS, based on OpenStreetMap data.
+* [MySQL](https://github.com/mysql/mysql-server) - Binary log transaction dependency tracking has used this map since 8.4.3 and 9.1.0, replacing a tree for the writeset history and taking about 60% less space for it.
+* [Valhalla](https://github.com/valhalla/valhalla) - Open source routing engine for OpenStreetMap data. Replaced robin-hood-hashing with this map and set in 3.6.0.
 
 ## 7. Ports
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ Additionally, there are `ankerl::unordered_dense::segmented_map` and `ankerl::un
   - [5.2. Lookups](#52-lookups)
   - [5.3. Removals](#53-removals)
 - [6. Real World Usage](#6-real-world-usage)
+  - [6.1. Databases and data engines](#61-databases-and-data-engines)
+  - [6.2. Games, emulators and game engines](#62-games-emulators-and-game-engines)
+  - [6.3. Graphics, rendering and GPU compute](#63-graphics-rendering-and-gpu-compute)
+  - [6.4. Maps and geospatial](#64-maps-and-geospatial)
+  - [6.5. CAD, 3D printing and simulation](#65-cad-3d-printing-and-simulation)
+  - [6.6. Bioinformatics](#66-bioinformatics)
+  - [6.7. Networking, media and security](#67-networking-media-and-security)
+  - [6.8. Finance and blockchain](#68-finance-and-blockchain)
+  - [6.9. Tools, libraries and machine learning](#69-tools-libraries-and-machine-learning)
 - [7. Ports](#7-ports)
 
 ## 1. Overview
@@ -360,26 +369,103 @@ Since all data is stored in a vector, removals are a bit more complicated:
 
 ## 6. Real World Usage
 
-On 2023-09-10 I did a quick search on GitHub to see if this map is used in any popular open source projects. Here are some of the projects I found, plus the ones whose authors have written in since. Please send me a note if you want to be on that list!
+Open source projects that use this map, grouped by what they do. The list was first put together on 2023-09-10 and last refreshed on 2026-08-06; every entry was confirmed by finding the include or the namespace in the project's own source on its default branch. Some authors have written in, the rest come from searching GitHub. Please send me a note if you want to be on that list!
 
-* [PrusaSlicer](https://github.com/prusa3d/PrusaSlicer) -  G-code generator for 3D printers (RepRap, Makerbot, Ultimaker etc.) 
-* [Kismet](https://github.com/kismetwireless/kismet): Wi-Fi, Bluetooth, RF, and more. Kismet is a sniffer, WIDS, and wardriving tool for Wi-Fi, Bluetooth, Zigbee, RF, and more, which runs on Linux and macOS
-* [Rspamd](https://github.com/rspamd/rspamd) - Fast, free and open-source spam filtering system.
-* [kallisto](https://github.com/pachterlab/kallisto) -  Near-optimal RNA-Seq quantification
-* [Slang](https://github.com/shader-slang/slang) - Slang is a shading language that makes it easier to build and maintain large shader codebases in a modular and extensible fashion.
-* [CyberFSR2](https://github.com/PotatoOfDoom/CyberFSR2) - Drop-in DLSS replacement with FSR 2.0 for various games such as Cyberpunk 2077.
-* [ossia score](https://github.com/ossia/score) - A free, open-source, cross-platform intermedia sequencer for precise and flexible scripting of interactive scenarios. 
-* [HiveWE](https://github.com/stijnherfst/HiveWE) - A Warcraft III World Editor (WE) that focusses on speed and ease of use.
-* [opentxs](https://github.com/Open-Transactions/opentxs) - The Open-Transactions project is a collaborative effort to develop a robust, commercial-grade, fully-featured, free-software toolkit implementing the OTX protocol as well as a full-strength financial cryptography library, API, GUI, command-line interface, and prototype notary server.
-* [LuisaCompute](https://github.com/LuisaGroup/LuisaCompute) - High-Performance Rendering Framework on Stream Architectures
-* [Lethe](https://github.com/lethe-cfd/lethe) - Lethe (pronounced /ˈliːθiː/) is open-source computational fluid dynamics (CFD) software which uses high-order continuous Galerkin formulations to solve the incompressible Navier–Stokes equations (among others).
-* [PECOS](https://github.com/amzn/pecos) - PECOS is a versatile and modular machine learning (ML) framework for fast learning and inference on problems with large output spaces, such as extreme multi-label ranking (XMR) and large-scale retrieval.
-* [Operon](https://github.com/heal-research/operon) - A modern C++ framework for symbolic regression that uses genetic programming to explore a hypothesis space of possible mathematical expressions in order to find the best-fitting model for a given regression target.
-* [MashMap](https://github.com/marbl/MashMap) - A fast approximate aligner for long DNA sequences
-* [minigpt4.cpp](https://github.com/Maknee/minigpt4.cpp) - Port of MiniGPT4 in C++ (4bit, 5bit, 6bit, 8bit, 16bit CPU inference with GGML)
-* [CoMaps](https://codeberg.org/comaps/comaps) - Privacy-focused offline maps and navigation for Android and iOS, based on OpenStreetMap data.
+### 6.1. Databases and data engines
+
+* [AliSQL](https://github.com/alibaba/AliSQL) - A MySQL branch originated from Alibaba Group.
+* [ArcticDB](https://github.com/man-group/ArcticDB) - A high performance, serverless DataFrame database built for the Python Data Science ecosystem.
+* [Bodo](https://github.com/bodo-ai/Bodo) - A high performance compute engine for Python data processing.
+* [Milvus](https://github.com/milvus-io/milvus) - A high-performance, cloud-native vector database built for scalable vector search.
 * [MySQL](https://github.com/mysql/mysql-server) - Binary log transaction dependency tracking has used this map since 8.4.3 and 9.1.0, replacing a tree for the writeset history and taking about 60% less space for it.
+* [Percona Server](https://github.com/percona/percona-server) - A free, fully compatible, enhanced and open source drop-in replacement for MySQL.
+* [Percona XtraBackup](https://github.com/percona/percona-xtrabackup) - Open source hot backup tool for InnoDB and XtraDB databases.
+* [RonDB](https://github.com/logicalclocks/rondb) - A distribution of NDB Cluster for real-time applications with high availability.
+
+### 6.2. Games, emulators and game engines
+
+* [Citron](https://github.com/citron-neo/emulator) - A Nintendo Switch emulator.
+* [CrystalEngine](https://github.com/neilmewada/CrystalEngine) - A Vulkan game engine with FrameGraph, PBR rendering and a declarative UI framework.
+* [DevilutionX](https://github.com/diasurgical/DevilutionX) - Diablo build for modern operating systems.
+* [FEX](https://github.com/FEX-Emu/FEX) - A fast usermode x86 and x86-64 emulator for Arm64 Linux.
+* [FOnline Engine](https://github.com/cvet/fonline) - A flexible cross-platform isometric game engine for multiplayer games.
+* [HiveWE](https://github.com/stijnherfst/HiveWE) - A Warcraft III World Editor (WE) that focusses on speed and ease of use.
+* [impacto](https://github.com/CommitteeOfZero/impacto) - A reimplementation of the "MAGES." visual novel engine.
+* [LandSandBoat](https://github.com/LandSandBoat/server) - A server emulator for Final Fantasy XI.
+* [Marathon Recompiled](https://github.com/sonicnext-dev/MarathonRecomp) - An unofficial PC port of the Xbox 360 version of Sonic the Hedgehog (2006), created via static recompilation.
+* [Nazara Engine](https://github.com/NazaraEngine/NazaraEngine) - A cross-platform framework aimed at (but not limited to) real-time applications and games.
+* [NVGT](https://github.com/samtupy/nvgt) - The Nonvisual Gaming Toolkit, a cross-platform audio game engine.
+* [Oxylus Engine](https://github.com/oxylusengine/Oxylus) - A data-driven Vulkan game engine built in C++.
+* [Project Alice](https://github.com/schombert/Project-Alice) - An open source recreation of the grand strategy game Victoria II.
+* [Unleashed Recompiled](https://github.com/hedge-dev/UnleashedRecomp) - An unofficial PC port of the Xbox 360 version of Sonic Unleashed, created via static recompilation.
+* [Visual Pinball](https://github.com/vpinball/vpinball) - An open source pinball table editor and simulator.
+
+### 6.3. Graphics, rendering and GPU compute
+
+* [AdaptiveCpp](https://github.com/AdaptiveCpp/AdaptiveCpp) - Compiler for multiple programming models (SYCL, C++ standard parallelism) for CPUs and GPUs from all vendors.
+* [CyberFSR2](https://github.com/PotatoOfDoom/CyberFSR2) - Drop-in DLSS replacement with FSR 2.0 for various games such as Cyberpunk 2077.
+* [D3D12_Research](https://github.com/simco50/D3D12_Research) - A hobby project to experiment with various modern rendering techniques in DirectX 12.
+* [LuisaCompute](https://github.com/LuisaGroup/LuisaCompute) - High-performance rendering framework on stream architectures.
+* [NVIDIA MDL SDK](https://github.com/NVIDIA/MDL-SDK) - The NVIDIA Material Definition Language SDK, for physically based material definitions in rendering applications.
+* [OptiScaler](https://github.com/optiscaler/OptiScaler) - Bridges upscaling and frame generation across GPUs, supporting DLSS2+, XeSS and FSR2+ inputs.
+* [Skyrim Community Shaders](https://github.com/community-shaders/skyrim-community-shaders) - Community-driven advanced graphics modifications for Skyrim AE, SE and VR.
+* [Slang](https://github.com/shader-slang/slang) - A shading language that makes it easier to build and maintain large shader codebases in a modular and extensible fashion.
+* [WinUI](https://github.com/microsoft/microsoft-ui-xaml) - A modern UI framework with a rich set of controls and styles, the native UI layer of the Windows App SDK.
+
+### 6.4. Maps and geospatial
+
+* [Cloudini](https://github.com/facontidavide/cloudini) - A point cloud compression library, with ROS/PCL integration.
+* [CoMaps](https://codeberg.org/comaps/comaps) - Privacy-focused offline maps and navigation for Android and iOS, based on OpenStreetMap data.
+* [HDMapping](https://github.com/MapsHD/HDMapping) - Open source software for mobile mapping, LiDAR odometry and point cloud registration.
+* [MapLibre Native](https://github.com/maplibre/maplibre-native) - Interactive vector tile maps for iOS, Android and other platforms.
 * [Valhalla](https://github.com/valhalla/valhalla) - Open source routing engine for OpenStreetMap data. Replaced robin-hood-hashing with this map and set in 3.6.0.
+
+### 6.5. CAD, 3D printing and simulation
+
+* [Bambu Studio](https://github.com/bambulab/BambuStudio) - PC software for BambuLab and other 3D printers.
+* [Lethe](https://github.com/chaos-polymtl/lethe) - Open-source computational fluid dynamics (CFD) software which uses high-order continuous Galerkin formulations to solve the incompressible Navier–Stokes equations (among others).
+* [PrusaSlicer](https://github.com/prusa3d/PrusaSlicer) - G-code generator for 3D printers (RepRap, Makerbot, Ultimaker etc.).
+* [web-ifc](https://github.com/ThatOpen/engine_web-ifc) - Reading and writing IFC files with Javascript, at native speeds.
+
+### 6.6. Bioinformatics
+
+* [GW](https://github.com/kcleal/gw) - Genome browser and variant annotation tool for interactive visualisation of sequencing data.
+* [kallisto](https://github.com/pachterlab/kallisto) - Near-optimal RNA-Seq quantification.
+* [MashMap](https://github.com/marbl/MashMap) - A fast approximate aligner for long DNA sequences.
+* [metaMDBG](https://github.com/GaetanBenoitDev/metaMDBG) - A lightweight assembler for long and accurate metagenomics reads.
+* [wfmash](https://github.com/waveygang/wfmash) - Base-accurate DNA sequence alignments using WFA and mashmap3.
+
+### 6.7. Networking, media and security
+
+* [Kismet](https://github.com/kismetwireless/kismet) - A sniffer, WIDS and wardriving tool for Wi-Fi, Bluetooth, Zigbee and RF, which runs on Linux and macOS.
+* [libossia](https://github.com/ossia/libossia) - A modern C++, cross-environment distributed object model for creative coding and interaction scoring.
+* [mediasoup](https://github.com/versatica/mediasoup) - Cutting edge WebRTC video conferencing SFU.
+* [ossia score](https://github.com/ossia/score) - A free, open-source, cross-platform intermedia sequencer for precise and flexible scripting of interactive scenarios.
+* [Rspamd](https://github.com/rspamd/rspamd) - Fast, free and open-source spam filtering system.
+* [YANET](https://github.com/yanet-platform/yanet) - A high performance framework for forwarding traffic based on DPDK.
+
+### 6.8. Finance and blockchain
+
+* [Cartesi Machine Emulator](https://github.com/cartesi/machine-emulator) - The off-chain RISC-V emulator implementation of the Cartesi Machine.
+* [Monad](https://github.com/category-labs/monad) - A high-performance EVM-compatible layer-1 blockchain client.
+* [opentxs](https://github.com/Open-Transactions/opentxs) - A free-software toolkit implementing the OTX protocol, together with a financial cryptography library, API, GUI, command-line interface and prototype notary server.
+* [RISC Zero](https://github.com/risc0/risc0) - A zero-knowledge verifiable general computing platform based on RISC-V.
+* [WonderTrader](https://github.com/wondertrader/wondertrader) - A one-stop quantitative research and trading framework.
+
+### 6.9. Tools, libraries and machine learning
+
+* [ArkScript](https://github.com/ArkScript-lang/Ark) - A small, fast, functional and scripting language for C++ projects.
+* [File Commander](https://github.com/VioletGiraffe/file-commander) - A cross-platform Total Commander-like orthodox file manager for Windows, Mac and Linux.
+* [FlashTokenizer](https://github.com/NLPOptimize/flash-tokenizer) - An efficient and optimized BERT tokenizer engine for LLM inference serving.
+* [Ichor](https://github.com/volt-software/Ichor) - A C++20 microservice bootstrapping framework focused on thread safety and dependency injection.
+* [minigpt4.cpp](https://github.com/Maknee/minigpt4.cpp) - Port of MiniGPT4 in C++ (4bit, 5bit, 6bit, 8bit, 16bit CPU inference with GGML).
+* [Nimble Commander](https://github.com/mikekazakov/nimble-commander) - A dual-pane file manager for macOS.
+* [Operon](https://github.com/heal-research/operon) - A modern C++ framework for symbolic regression that uses genetic programming to find the best-fitting model for a given regression target.
+* [PECOS](https://github.com/amzn/pecos) - A versatile and modular machine learning framework for fast learning and inference on problems with large output spaces, such as extreme multi-label ranking and large-scale retrieval.
+* [PlotJuggler](https://github.com/PlotJuggler/PlotJuggler) - The time series visualization tool that you deserve.
+* [PyOptInterface](https://github.com/metab0t/PyOptInterface) - Efficient modeling interface for mathematical optimization in Python.
+* [STP](https://github.com/stp/stp) - Simple Theorem Prover, an efficient SMT solver for bitvectors.
+* [Tulip](https://github.com/Tulip-Dev/tulip) - Large graphs analysis, drawing and visualization framework.
 
 ## 7. Ports
 


### PR DESCRIPTION
Closes #158, closes #160. README only.

### CoMaps (#158)

Offline maps and navigation for Android and iOS. One of its developers wrote in to say they had adopted the map, which is what the list asks people to do. The intro no longer describes itself as purely the result of one GitHub search — CoMaps is on Codeberg and would never have turned up in one.

### Ports (#160)

The C99 port had nowhere to go: the usage list is for projects that *use* this library, not reimplementations of it. It now has its own subsection, with a line saying these are not maintained here.

### Both links were checked, and neither issue's was quite right

- **#160's link is stale.** The port has been renamed since it was filed: `benanil/HashMapAnkerlC99` is now `benanil/HashMapC99`. GitHub redirects the old name, but the README uses the current one rather than depending on that.
- **#158's link 404s.** The commit it points to no longer resolves. The project itself is fine, and its tree carries `3party/ankerl/unordered_dense.h` with `docs/CPP_STYLE.md` telling contributors to prefer `ankerl::unordered_dense::map` over `std::unordered_map` — so the entry rests on that rather than on the dead link.

### A refreshed list, grouped

The list was last refreshed on 2023-09-10 and had grown into a flat run of bullets. It is now grouped by what the projects do — databases, games, graphics, maps, CAD, bioinformatics, networking, blockchain, tools, ports — alphabetical within each group, and it went from 18 entries to 69.

Every new entry was confirmed by fetching the cited file from the project's default branch and finding the include or the namespace in it, rather than trusting a search snippet. Among them: Milvus, WinUI, FEX, mediasoup, DevilutionX, OptiScaler, MapLibre Native, AdaptiveCpp, NVIDIA MDL SDK, Percona Server, ArcticDB, RISC Zero.

Two fixes to entries that were already there:

- **Lethe has moved** to `chaos-polymtl/lethe`. The old `lethe-cfd/lethe` still redirects, so the link was not broken, just no longer canonical.
- **libossia is now listed** alongside ossia score, because that is where the include actually lives.

Deliberately left out: **OpenSim Creator**, which vendors the library and updates it, but where no usage site in its own source could be found; and three smaller MySQL derivatives that inherit `extra/unordered_dense` from the MySQL tree and so add nothing beyond the MySQL entry.

The search that found these hit GitHub's 1000-result API cap on its three highest-volume queries, so it saw roughly a quarter of the include-path hits. More large users are likely still out there.

The table of contents is written out in the file rather than generated, so it gained the new subsections too.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxhyeMXim7Pvb8SmYoEdBk)_